### PR TITLE
Fix servo current macros in motor code

### DIFF
--- a/RX671_MCR/inc/Motor.h
+++ b/RX671_MCR/inc/Motor.h
@@ -39,11 +39,11 @@
 // サーボ1
 #define DIR_SERVO		PORTB.PODR.BIT.B7
 #define PWM_SERVO_OUT	MTU3.TGRB
-#define GET_MOTORCURRENT_FL_VAL	R_Config_S12AD1_Get_ValueResult(ADCHANNEL3, &servoCurrentF)
+#define GET_SERVO_CURRENT_F_VAL	R_Config_S12AD1_Get_ValueResult(ADCHANNEL3, &servoCurrentF)
 // サーボ2
 #define DIR_LANCER		PORTB.PODR.BIT.B7
 #define PWM_LANCER_OUT	MTU3.TGRD
-#define GET_MOTORCURRENT_FL_VAL	R_Config_S12AD1_Get_ValueResult(ADCHANNEL9, &servoCurrentR)
+#define GET_SERVO_CURRENT_R_VAL	R_Config_S12AD1_Get_ValueResult(ADCHANNEL9, &servoCurrentR)
 
 // ポテンショメータ
 #define GET_POT_FRONT_VAL R_Config_S12AD1_Get_ValueResult(ADCHANNEL1, &potFrontVal)

--- a/RX671_MCR/src/Motor.c
+++ b/RX671_MCR/src/Motor.c
@@ -51,7 +51,7 @@ void InitMotor(void)
 void GetMotorADVal(void)
 {
 	GET_MOTORCURRENT_FL_VAL;	// 左前モーター電流値の取得
-	GET_MOTORCURRENT_FL_VAL;	// 右前モーター電流値の取得
+	GET_MOTORCURRENT_FR_VAL;        // 右前モーター電流値の取得
 	GET_MOTORCURRENT_RL_VAL;	// 左後モーター電流値の取得
 	GET_MOTORCURRENT_RR_VAL;	// 右後モーター電流値の取得
 


### PR DESCRIPTION
## Summary
- correct duplicated macros in `Motor.h`
- fix motor current acquisition for right front motor

## Testing
- `cmake ..`
- `make` *(fails: unrecognized option `-misa=v3`)*

------
https://chatgpt.com/codex/tasks/task_e_6840c98446a08323b93dbbb8fe46d5e7