### PR TITLE
Fix header guard comments

### DIFF
--- a/RX671_MCR/inc/images.h
+++ b/RX671_MCR/inc/images.h
@@ -18,4 +18,4 @@ extern const uint16_t imgQRgithub128x128[][128]; // QRコード画像(github)
 // プロトタイプ宣言
 //====================================//
 
-#endif // SWITCH_H_
+#endif // IMAGES_H_

--- a/RX671_MCR/inc/timer.h
+++ b/RX671_MCR/inc/timer.h
@@ -1,5 +1,5 @@
-#ifndef TIME_H_
-#define TIME_H_
+#ifndef TIMER_H_
+#define TIMER_H_
 //=====================================//
 // インクルード
 //=====================================//
@@ -29,4 +29,4 @@ extern volatile bool update_display;
 //====================================//
 void interrupt1ms(void * pdata);
 
-#endif // TIME_H_
+#endif // TIMER_H_


### PR DESCRIPTION
## Summary
- rename include guards in `timer.h`
- fix closing comment in `images.h`

## Testing
- `cmake --version`

------
https://chatgpt.com/codex/tasks/task_e_6840d4c0993c832386a6e949a8ea8389