### PR TITLE
Fix timer includes and status bar display

### DIFF
--- a/RX671_MCR/inc/gui.h
+++ b/RX671_MCR/inc/gui.h
@@ -6,6 +6,7 @@
 #include "ssd1351.h"
 #include "switch.h"
 #include "r_smc_entry.h"
+#include "battery.h"
 //====================================//
 // プロトタイプ宣言
 //====================================//
@@ -13,5 +14,6 @@
 void GUI_ShowStartup(void);
 void GUI_ShowMenu(const char **items, uint8_t count, uint8_t selected);
 uint8_t GUI_MenuSelect(const char **items, uint8_t count);
+void GUI_ShowStatusBar(void);
 
 #endif // GUI_H_

--- a/RX671_MCR/inc/timer.h
+++ b/RX671_MCR/inc/timer.h
@@ -9,6 +9,8 @@
 #include "ssd1351.h"
 #include "switch.h"
 #include "encoder.h"
+#include "battery.h"
+#include "gui.h"
 
 #include <stdio.h>
 #include <stdint.h>

--- a/RX671_MCR/src/gui.c
+++ b/RX671_MCR/src/gui.c
@@ -84,3 +84,18 @@ uint8_t GUI_MenuSelect(const char **items, uint8_t count)
     }
 }
 
+/////////////////////////////////////////////////////////////////////
+// モジュール名 GUI_ShowStatusBar
+// 処理概要     ステータスバーにバッテリー残量を表示する
+// 引数         なし
+// 戻り値       なし
+/////////////////////////////////////////////////////////////////////
+void GUI_ShowStatusBar(void)
+{
+    uint8_t percent = (uint8_t)((batteryVoltage / 12.0F) * 100.0F + 0.5F);
+    if(percent > 100) percent = 100;
+    SSD1351fillRectangle(0, 0, SSD1351_WIDTH - 1, 9, SSD1351_BLACK);
+    SSD1351setCursor(2, 0);
+    SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"BAT:%3d%%", percent);
+}
+

--- a/RX671_MCR/src/timer.c
+++ b/RX671_MCR/src/timer.c
@@ -25,9 +25,9 @@ void interrupt1ms(void * pdata)
 		SSD1351updateScreen();
 	}
 	
-	GetSwitches();
-	R_SDC_SD_1msInterval();
-	GetEncoderVal();
+        GetSwitches();
+        R_SDC_SD_1msInterval();
+        GetEncoderVal();
 
 	switch (cnt10)
 	{
@@ -48,25 +48,29 @@ void interrupt1ms(void * pdata)
 			calibrationIMU();
 		}
 		break;
-	case 3:
-		if(initSDcard && loggingSDcard)
-		{
-			f_printf(&file, formatLog
-				,cnt0
-				,BMI088val.accele.x
-				,BMI088val.accele.y
-				,BMI088val.accele.z
-				,BMI088val.gyro.x
-				,BMI088val.gyro.y
-				,BMI088val.gyro.z
-				,BMI088val.angle.x
-				,BMI088val.angle.y
-				,BMI088val.angle.z
-				,BMI088val.temp);
-		}
-		break;
-	case 10:
-		cnt10 = 0;
-		break;
-	}
+        case 3:
+                if(initSDcard && loggingSDcard)
+                {
+                        f_printf(&file, formatLog
+                                ,cnt0
+                                ,BMI088val.accele.x
+                                ,BMI088val.accele.y
+                                ,BMI088val.accele.z
+                                ,BMI088val.gyro.x
+                                ,BMI088val.gyro.y
+                                ,BMI088val.gyro.z
+                                ,BMI088val.angle.x
+                                ,BMI088val.angle.y
+                                ,BMI088val.angle.z
+                                ,BMI088val.temp);
+                }
+                break;
+        case 4:
+                GetBatteryADVal();
+                GUI_ShowStatusBar();
+                break;
+       case 10:
+               cnt10 = 0;
+               break;
+        }
 }


### PR DESCRIPTION
## Summary
- move `battery.h` include into `gui.h`
- compute battery percent inside `GUI_ShowStatusBar`
- call `GUI_ShowStatusBar` on cnt10==4 from timer interrupt

## Testing
- `cmake .`
- `make -j$(nproc)` *(fails: unrecognized command line option)*

------
https://chatgpt.com/codex/tasks/task_e_6843bdd620748323a27236c3f2a87a7e