### PR TITLE
Implement page switching

### DIFF
--- a/RX671_MCR/inc/gui.h
+++ b/RX671_MCR/inc/gui.h
@@ -14,6 +14,6 @@
 void GUI_ShowStartup(void);
 void GUI_ShowMenu(const char **items, uint8_t count, uint8_t selected, uint8_t offset);
 uint8_t GUI_MenuSelect(const char **items, uint8_t count);
-void GUI_ShowStatusBar(void);
+void GUI_ShowStatusBar(uint8_t page);
 
 #endif // GUI_H_

--- a/RX671_MCR/src/RX671_MCR.c
+++ b/RX671_MCR/src/RX671_MCR.c
@@ -30,6 +30,7 @@
 #define CMT_CHANNEL 0
 
 char read_buf[64];
+static uint8_t currentPage = 0;
 
 void main(void);
 
@@ -46,19 +47,19 @@ void main(void)
 
 	R_Config_SCI2_Start();
 	BMI088init();
-    SSD1351init();
-    GUI_ShowStartup();
+	SSD1351init();
+	GUI_ShowStartup();
 
-    // 赤枠描画
+	// 赤枠描画
 	for(int x = 0; x < SSD1351_WIDTH; x++) {
-        SSD1351drawPixel(x, 0, SSD1351_RED);
-        SSD1351drawPixel(x, SSD1351_HEIGHT-1, SSD1351_RED);
-    }
+	    SSD1351drawPixel(x, 0, SSD1351_RED);
+	    SSD1351drawPixel(x, SSD1351_HEIGHT-1, SSD1351_RED);
+	}
 
-    for(int y = 0; y < SSD1351_HEIGHT; y++) {
-        SSD1351drawPixel(0, y, SSD1351_RED);
-        SSD1351drawPixel(SSD1351_WIDTH-1, y, SSD1351_RED);
-    }
+	for(int y = 0; y < SSD1351_HEIGHT; y++) {
+	    SSD1351drawPixel(0, y, SSD1351_RED);
+	    SSD1351drawPixel(SSD1351_WIDTH-1, y, SSD1351_RED);
+	}
 
 	R_BSP_SoftwareDelay(1000,BSP_DELAY_MILLISECS);
 	calibratIMU = true;	// IMUキャリブレーション開始
@@ -99,7 +100,8 @@ void main(void)
 
 	// 電源電圧を表示
 	GetBatteryVoltage();
-	GUI_ShowStatusBar();
+	currentPage = swValRotary;
+	GUI_ShowStatusBar(currentPage);
 
 	const char *menu_items[] = {
 		  "START   "
@@ -118,7 +120,7 @@ void main(void)
 		, "INFO12  "
 		, "INFO13  "
 	};
-    GUI_ShowMenu(menu_items, 14, 0, 0);
+	GUI_ShowMenu(menu_items, 14, 0, 0);
 
 	while (1)
 	{
@@ -131,7 +133,14 @@ void main(void)
 			SDcardinit(); // SDカードの初期化
 		}
 
+
 		GUI_MenuSelect(menu_items, 14);
+
+		if(swValRotary != currentPage)
+		{
+			currentPage = swValRotary;
+			GUI_ShowStatusBar(currentPage);
+		}
 
 		// SSD1351setCursor(2,2);
 		// SSD1351printf(Font_7x10,SSD1351_BLUE,"x:%4d",(int32_t)BMI088val.angle.x);

--- a/RX671_MCR/src/gui.c
+++ b/RX671_MCR/src/gui.c
@@ -22,9 +22,9 @@
 /////////////////////////////////////////////////////////////////////
 void GUI_ShowStartup(void)
 {
-    SSD1351fill(SSD1351_BLACK);
-    SSD1351setCursor(10, 54);
-    SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"RX671_MCR");
+	SSD1351fill(SSD1351_BLACK);
+	SSD1351setCursor(10, 54);
+	SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"RX671_MCR");
 }
 
 /////////////////////////////////////////////////////////////////////
@@ -40,22 +40,22 @@ void GUI_ShowStartup(void)
 /////////////////////////////////////////////////////////////////////
 void GUI_ShowMenu(const char **items, uint8_t count, uint8_t selected, uint8_t offset)
 {
-    // メニュー表示エリアを一旦クリアする
-    SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1, SSD1351_HEIGHT - 1, SSD1351_BLACK);
+	// メニュー表示エリアを一旦クリアする
+	SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1, SSD1351_HEIGHT - 1, SSD1351_BLACK);
 
-    // 表示できる最大行数を求め、offset から表示する数を決定
-    uint8_t visible = MAX_VISIBLE_ITEMS;
-    uint8_t show = (count - offset < visible) ? (count - offset) : visible;
+	// 表示できる最大行数を求め、offset から表示する数を決定
+	uint8_t visible = MAX_VISIBLE_ITEMS;
+	uint8_t show = (count - offset < visible) ? (count - offset) : visible;
 
-    for(uint8_t i = 0; i < show; i++)
-    {
-        uint8_t idx = offset + i;
-        // 表示行を設定
-        SSD1351setCursor(2, (uint8_t)(i * MENU_ITEM_HEIGHT + MENU_START_Y));
-        // 選択中は黄色で表示
-        uint16_t color = (idx == selected) ? SSD1351_YELLOW : SSD1351_WHITE;
-        SSD1351printf(Font_7x10, color, (uint8_t*)items[idx]);
-    }
+	for(uint8_t i = 0; i < show; i++)
+	{
+	    uint8_t idx = offset + i;
+	    // 表示行を設定
+	    SSD1351setCursor(2, (uint8_t)(i * MENU_ITEM_HEIGHT + MENU_START_Y));
+	    // 選択中は黄色で表示
+	    uint16_t color = (idx == selected) ? SSD1351_YELLOW : SSD1351_WHITE;
+	    SSD1351printf(Font_7x10, color, (uint8_t*)items[idx]);
+	}
 }
 
 /////////////////////////////////////////////////////////////////////
@@ -67,10 +67,10 @@ void GUI_ShowMenu(const char **items, uint8_t count, uint8_t selected, uint8_t o
 /////////////////////////////////////////////////////////////////////
 uint8_t GUI_MenuSelect(const char **items, uint8_t count)
 {
-    static uint8_t index = 0;
-    static uint8_t top   = 0;
+	static uint8_t index = 0;
+	static uint8_t top   = 0;
 
-    GUI_ShowMenu(items, count, index, top);
+	GUI_ShowMenu(items, count, index, top);
 
 	switch(swValTact)
 	{
@@ -128,16 +128,18 @@ uint8_t GUI_MenuSelect(const char **items, uint8_t count)
 
 /////////////////////////////////////////////////////////////////////
 // モジュール名 GUI_ShowStatusBar
-// 処理概要     ステータスバーにバッテリー残量を表示する
-// 引数         なし
+// 処理概要     ステータスバーにページ番号とバッテリー残量を表示する
+// 引数         page : 表示するページ番号
 // 戻り値       なし
 /////////////////////////////////////////////////////////////////////
-void GUI_ShowStatusBar(void)
+void GUI_ShowStatusBar(uint8_t page)
 {
-    uint8_t percent = (uint8_t)((batteryVoltage / 12.0F) * 100.0F + 0.5F);
-    if(percent > 100) percent = 100;
-    // SSD1351fillRectangle(0, 0, SSD1351_WIDTH - 1, 9, SSD1351_BLACK);
-    SSD1351setCursor(71, 0);
-    SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"BAT:%3d%%", percent);
+	uint8_t percent = (uint8_t)((batteryVoltage / 12.0F) * 100.0F + 0.5F);
+	if(percent > 100) percent = 100;
+	SSD1351fillRectangle(0, 0, SSD1351_WIDTH - 1, 9, SSD1351_BLACK);
+	SSD1351setCursor(2, 0);
+	SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"P:%d", page);
+	SSD1351setCursor(71, 0);
+	SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"BAT:%3d%%", percent);
 }
 


### PR DESCRIPTION
## Summary
- display page number in status bar
- track rotary switch value to update page
- clear status bar and show battery percentage along with page
- fix brace and comment indentation
- replace space indentation with tabs

## Testing
- `cmake -S RX671_MCR -B build`
- `cmake --build build` *(fails: unrecognized command-line option)*


------
https://chatgpt.com/codex/tasks/task_e_68443504bcb48323b441930b13aa6851