### PR TITLE
Add GUI contrast adjustment

### DIFF
--- a/RX671_MCR/inc/BMI088.h
+++ b/RX671_MCR/inc/BMI088.h
@@ -77,6 +77,7 @@ extern volatile bool spi_BMI088_tx_done;
 extern volatile bool spi_BMI088_rx_done;
 extern IMUval BMI088val;
 extern volatile bool calibratIMU;
+extern bool bmi088_read_locked;
 //====================================//
 // プロトタイプ宣言
 //====================================//

--- a/RX671_MCR/inc/gui.h
+++ b/RX671_MCR/inc/gui.h
@@ -14,5 +14,7 @@ void GUI_ShowStartup(void);
 void GUI_ShowMenu(const char **items, uint8_t count, uint8_t selected, uint8_t offset);
 uint8_t GUI_MenuSelect(const char **items, uint8_t count);
 void GUI_ShowStatusBar(uint8_t page);
+bool GUI_EditContrastRGB(void);
+bool GUI_EditContrastMaster(void);
 
 #endif // GUI_H_

--- a/RX671_MCR/src/BMI088.c
+++ b/RX671_MCR/src/BMI088.c
@@ -12,6 +12,7 @@ axis angle = {0.0F, 0.0F, 0.0F};
 IMUval BMI088val;
 volatile bool spi_BMI088_tx_done = false;
 volatile bool spi_BMI088_rx_done = false;
+bool bmi088_read_locked = false;
 
 int16_t angleOffset[3] = {0, 0, 0};
 volatile bool calibratIMU = false;

--- a/RX671_MCR/src/RX671_MCR.c
+++ b/RX671_MCR/src/RX671_MCR.c
@@ -51,13 +51,13 @@ void main(void)
 
 	// 赤枠描画
 	for(int x = 0; x < SSD1351_WIDTH; x++) {
-	    SSD1351drawPixel(x, 0, SSD1351_RED);
-	    SSD1351drawPixel(x, SSD1351_HEIGHT-1, SSD1351_RED);
+		SSD1351drawPixel(x, 0, SSD1351_RED);
+		SSD1351drawPixel(x, SSD1351_HEIGHT-1, SSD1351_RED);
 	}
 
 	for(int y = 0; y < SSD1351_HEIGHT; y++) {
-	    SSD1351drawPixel(0, y, SSD1351_RED);
-	    SSD1351drawPixel(SSD1351_WIDTH-1, y, SSD1351_RED);
+		SSD1351drawPixel(0, y, SSD1351_RED);
+		SSD1351drawPixel(SSD1351_WIDTH-1, y, SSD1351_RED);
 	}
 
 	R_BSP_SoftwareDelay(1000,BSP_DELAY_MILLISECS);
@@ -140,9 +140,9 @@ void main(void)
 		// ステータスバー表示
 		if(swValRotary != currentPage)
 		{
-			SSD1351fill(SSD1351_BLACK);
-			currentPage = swValRotary;
-			GUI_ShowStatusBar(currentPage);
+		SSD1351fill(SSD1351_BLACK);
+		currentPage = swValRotary;
+		GUI_ShowStatusBar(currentPage);
 		}
 
 		// ページ表示
@@ -151,10 +151,27 @@ void main(void)
 				// STARTページ
 				GUI_MenuSelect(menu1_items, 14);
 				break;
-			case 1:
-				// SETTINGSページ
-				GUI_MenuSelect(menu2_items, 2);
-				break;
+case 1:
+// SETTINGSページ
+{
+uint8_t sel = GUI_MenuSelect(menu2_items, 2);
+if(sel == 0)
+{
+while(!GUI_EditContrastRGB())
+{
+}
+SSD1351fill(SSD1351_BLACK);
+}
+else if(sel == 1)
+{
+while(!GUI_EditContrastMaster())
+{
+}
+SSD1351fill(SSD1351_BLACK);
+}
+}
+break;
+break;
 			default:
 				break;
 		}

--- a/RX671_MCR/src/gui.c
+++ b/RX671_MCR/src/gui.c
@@ -39,8 +39,8 @@ void GUI_ShowStartup(void)
 /////////////////////////////////////////////////////////////////////
 void GUI_ShowMenu(const char **items, uint8_t count, uint8_t selected, uint8_t offset)
 {
-    // メニュー表示エリアを一旦クリアする
-    // SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1, SSD1351_HEIGHT - 1, SSD1351_BLACK);
+	// メニュー表示エリアを一旦クリアする
+	// SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1, SSD1351_HEIGHT - 1, SSD1351_BLACK);
 
 	// 表示できる最大行数を求め、offset から表示する数を決定
 	uint8_t visible = MAX_VISIBLE_ITEMS;
@@ -48,12 +48,12 @@ void GUI_ShowMenu(const char **items, uint8_t count, uint8_t selected, uint8_t o
 
 	for(uint8_t i = 0; i < show; i++)
 	{
-	    uint8_t idx = offset + i;
-	    // 表示行を設定
-	    SSD1351setCursor(2, (uint8_t)(i * MENU_ITEM_HEIGHT + MENU_START_Y));
-	    // 選択中は黄色で表示
-	    uint16_t color = (idx == selected) ? SSD1351_YELLOW : SSD1351_WHITE;
-	    SSD1351printf(Font_7x10, color, (uint8_t*)items[idx]);
+		uint8_t idx = offset + i;
+		// 表示行を設定
+		SSD1351setCursor(2, (uint8_t)(i * MENU_ITEM_HEIGHT + MENU_START_Y));
+		// 選択中は黄色で表示
+		uint16_t color = (idx == selected) ? SSD1351_YELLOW : SSD1351_WHITE;
+		SSD1351printf(Font_7x10, color, (uint8_t*)items[idx]);
 	}
 }
 /////////////////////////////////////////////////////////////////////
@@ -122,6 +122,8 @@ uint8_t GUI_MenuSelect(const char **items, uint8_t count)
 	default:
 		break;
 	}
+
+	return 0xFF;
 }
 /////////////////////////////////////////////////////////////////////
 // モジュール名 GUI_ShowStatusBar
@@ -138,5 +140,119 @@ void GUI_ShowStatusBar(uint8_t page)
 	SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"P:%x", page);
 	SSD1351setCursor(71, 0);
 	SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"BAT:%3d%%", percent);
+}
+
+/////////////////////////////////////////////////////////////////////
+// モジュール名 GUI_EditContrastRGB
+// 処理概要     RGBコントラストを編集する
+// 引数         なし
+// 戻り値       true:編集終了
+/////////////////////////////////////////////////////////////////////
+bool GUI_EditContrastRGB(void)
+{
+	static uint8_t contrast = 0x64;
+	static bool init = false;
+
+	if(!init)
+	{
+	SSD1351fill(SSD1351_BLACK);
+	init = true;
+	}
+
+	SSD1351setCursor(2, 20);
+	SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"RGB CONT");
+	SSD1351setCursor(2, 36);
+	SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"VAL:%3d", contrast);
+
+	switch(swValTact)
+	{
+	case SW_LEFT:
+		if(contrast > 0) contrast--;
+		display_update_locked = true;
+		bmi088_read_locked = true;
+		// SPIバスがフリーになるまで待機
+		while(!spi_ssd1351_tx_done || !spi_BMI088_tx_done);
+		SSD1351setContrastRGB(contrast, contrast, contrast);
+		display_update_locked = false;
+		bmi088_read_locked = false;
+		R_BSP_SoftwareDelay(150, BSP_DELAY_MILLISECS);
+	break;
+	case SW_RIGHT:
+		if(contrast < 255) contrast++;
+		display_update_locked = true;
+		bmi088_read_locked = true;
+		// SPIバスがフリーになるまで待機
+		while(!spi_ssd1351_tx_done || !spi_BMI088_tx_done);
+		SSD1351setContrastRGB(contrast, contrast, contrast);
+		display_update_locked = false;
+		bmi088_read_locked = false;
+		R_BSP_SoftwareDelay(150, BSP_DELAY_MILLISECS);
+	break;
+	case SW_PUSH:
+	R_BSP_SoftwareDelay(150, BSP_DELAY_MILLISECS);
+	init = false;
+	return true;
+	default:
+	break;
+	}
+
+	return false;
+}
+
+/////////////////////////////////////////////////////////////////////
+// モジュール名 GUI_EditContrastMaster
+// 処理概要     マスターコントラストを編集する
+// 引数         なし
+// 戻り値       true:編集終了
+/////////////////////////////////////////////////////////////////////
+bool GUI_EditContrastMaster(void)
+{
+	static uint8_t contrast = 0x08;
+	static bool init = false;
+
+	if(!init)
+	{
+	SSD1351fill(SSD1351_BLACK);
+	init = true;
+	}
+
+	SSD1351setCursor(2, 20);
+	SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"MASTER CONT");
+	SSD1351setCursor(2, 36);
+	SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"VAL:%3d", contrast);
+
+	switch(swValTact)
+	{
+	case SW_LEFT:
+		if(contrast > 0) contrast--;
+		display_update_locked = true;
+		bmi088_read_locked = true;
+		// SPIバスがフリーになるまで待機
+		while(!spi_ssd1351_tx_done || !spi_BMI088_tx_done);
+		SSD1351setContrastMaster(contrast);
+		display_update_locked = false;
+		bmi088_read_locked = false;
+		R_BSP_SoftwareDelay(150, BSP_DELAY_MILLISECS);
+	break;
+	case SW_RIGHT:
+		if(contrast < 255) contrast++;
+		display_update_locked = true;
+		bmi088_read_locked = true;
+		// SPIバスがフリーになるまで待機
+		while(!spi_ssd1351_tx_done || !spi_BMI088_tx_done);
+		SSD1351setContrastMaster(contrast);
+		display_update_locked = false;
+		bmi088_read_locked = false;
+		R_BSP_SoftwareDelay(150, BSP_DELAY_MILLISECS);
+	break;
+	case SW_PUSH:
+		R_BSP_SoftwareDelay(150, BSP_DELAY_MILLISECS);
+		init = false;
+		return true;
+	default:
+	break;
+	}
+
+	return false;
 }
 

--- a/RX671_MCR/src/ssd1351.c
+++ b/RX671_MCR/src/ssd1351.c
@@ -10,6 +10,7 @@
 //====================================//
 volatile bool spi_ssd1351_tx_done = false;
 volatile bool g_dma_transfer_done = false;
+bool display_update_locked = false;
 
 static U16ToU8_Union SSD1351_Buffer;	// Screenbuffer
 static U16ToU8_Union SSD1351_BufferBefore;	// Screenbuffer

--- a/RX671_MCR/src/timer.c
+++ b/RX671_MCR/src/timer.c
@@ -19,10 +19,10 @@ void interrupt1ms(void * pdata)
 	cnt0++;
 	cnt10++;
 
-	if(!loggingSDcard)
-	{
-		SSD1351updateScreen();
-	}
+if(!loggingSDcard && !display_update_locked)
+{
+SSD1351updateScreen();
+}
 	
 	GetSwitches();
 	R_SDC_SD_1msInterval();
@@ -32,7 +32,7 @@ void interrupt1ms(void * pdata)
 	{
 	case 1:
 		
-		if(BMI088val.Initialized && !calibratIMU)
+		if(BMI088val.Initialized && !calibratIMU && !bmi088_read_locked)
 		{
 			BMI088getGyro(); // 角速度取得
 			BMI088getTemp();


### PR DESCRIPTION
## Summary
- enable GUI editing of display contrast
- disable display updates and IMU reads while changing contrast
- wait for SPI bus to be free before sending contrast commands
- drop status bar updates
- restore status bar when switching pages and fix indentation

## Testing
- `cmake -S RX671_MCR -B build -DCMAKE_TOOLCHAIN_FILE=$PWD/RX671_MCR/cross.cmake` *(fails: compiler not found)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*


------
https://chatgpt.com/codex/tasks/task_e_6844f60a2ae48323a466af0c4966ed43