### PR TITLE
Add sensor display page

### DIFF
--- a/RX671_MCR/.settings/e2studio_project.prefs
+++ b/RX671_MCR/.settings/e2studio_project.prefs
@@ -1,3 +1,3 @@
 #
-#Tue Jun 10 06:56:34 CST 2025
+#Thu Jun 12 06:16:22 CST 2025
 activeConfiguration=com.renesas.cdt.managedbuild.gcc.rx.configuration.debug.update.1331949664

--- a/RX671_MCR/.settings/e2studio_project.prefs
+++ b/RX671_MCR/.settings/e2studio_project.prefs
@@ -1,3 +1,3 @@
 #
-#Thu Jun 12 06:16:22 CST 2025
+#Sat Jun 14 21:10:13 JST 2025
 activeConfiguration=com.renesas.cdt.managedbuild.gcc.rx.configuration.debug.update.1331949664

--- a/RX671_MCR/inc/gui.h
+++ b/RX671_MCR/inc/gui.h
@@ -5,7 +5,6 @@
 //====================================//
 #include "r_smc_entry.h"
 
-void GUI_ResetSensorsPage(void);
 #include <stdint.h>
 
 #include "ssd1351.h"

--- a/RX671_MCR/inc/gui.h
+++ b/RX671_MCR/inc/gui.h
@@ -5,6 +5,7 @@
 //====================================//
 #include "r_smc_entry.h"
 
+void GUI_ResetSensorsPage(void);
 #include <stdint.h>
 
 #include "ssd1351.h"

--- a/RX671_MCR/inc/gui.h
+++ b/RX671_MCR/inc/gui.h
@@ -6,6 +6,7 @@
 #include "r_smc_entry.h"
 
 bool GUI_ShowSensors(void);
+void GUI_ResetSensorsPage(void);
 
 #include "ssd1351.h"
 #include "switch.h"

--- a/RX671_MCR/inc/gui.h
+++ b/RX671_MCR/inc/gui.h
@@ -5,7 +5,7 @@
 //====================================//
 #include "r_smc_entry.h"
 
-#include <stdint.h>
+bool GUI_ShowSensors(void);
 
 #include "ssd1351.h"
 #include "switch.h"

--- a/RX671_MCR/inc/gui.h
+++ b/RX671_MCR/inc/gui.h
@@ -5,13 +5,24 @@
 //====================================//
 #include "r_smc_entry.h"
 
-bool GUI_ShowSensors(void);
-
 #include "ssd1351.h"
 #include "switch.h"
 #include "battery.h"
 #include "bmi088.h"
 #include "linesensor.h"
+#include "encoder.h"
+#include <stdbool.h>
+#include <stdint.h>
+//=====================================//
+// シンボル定義
+//=====================================//
+// メニュー表示に関する定数
+// MENU_START_Y : メニューエリアの開始Y座標
+// MENU_ITEM_HEIGHT : 1行あたりの高さ
+// MAX_VISIBLE_ITEMS : 一度に表示できる行数
+#define MENU_START_Y 12
+#define MENU_ITEM_HEIGHT 12
+#define MAX_VISIBLE_ITEMS (((SSD1351_HEIGHT - MENU_START_Y) / MENU_ITEM_HEIGHT) + 1)
 
 //====================================//
 // グローバル変数の宣言
@@ -29,5 +40,5 @@ bool GUI_EditContrast(void);
 void GUI_DrawTestPattern(uint8_t y_start);
 bool GUI_DisplayInverse(void);
 bool GUI_ShowQRcode(void);
-void GUI_ShowSensors(void);
+bool GUI_ShowSensors(void);
 #endif // GUI_H_

--- a/RX671_MCR/inc/gui.h
+++ b/RX671_MCR/inc/gui.h
@@ -6,7 +6,6 @@
 #include "r_smc_entry.h"
 
 bool GUI_ShowSensors(void);
-void GUI_ResetSensorsPage(void);
 
 #include "ssd1351.h"
 #include "switch.h"

--- a/RX671_MCR/inc/gui.h
+++ b/RX671_MCR/inc/gui.h
@@ -4,11 +4,14 @@
 // インクルード
 //====================================//
 #include "r_smc_entry.h"
+
+#include <stdint.h>
+
 #include "ssd1351.h"
 #include "switch.h"
 #include "battery.h"
 #include "bmi088.h"
-#include <stdint.h>
+#include "linesensor.h"
 
 //====================================//
 // グローバル変数の宣言

--- a/RX671_MCR/inc/gui.h
+++ b/RX671_MCR/inc/gui.h
@@ -27,4 +27,5 @@ void GUI_DrawTestPattern(uint8_t y_start);
 bool GUI_DisplayInverse(void);
 bool GUI_ShowQRcode(void);
 void GUI_ShowSensors(void);
+void GUI_ResetSensorsPage(void);
 #endif // GUI_H_

--- a/RX671_MCR/inc/gui.h
+++ b/RX671_MCR/inc/gui.h
@@ -26,4 +26,5 @@ bool GUI_EditContrast(void);
 void GUI_DrawTestPattern(uint8_t y_start);
 bool GUI_DisplayInverse(void);
 bool GUI_ShowQRcode(void);
+void GUI_ShowSensors(void);
 #endif // GUI_H_

--- a/RX671_MCR/inc/gui.h
+++ b/RX671_MCR/inc/gui.h
@@ -27,5 +27,4 @@ void GUI_DrawTestPattern(uint8_t y_start);
 bool GUI_DisplayInverse(void);
 bool GUI_ShowQRcode(void);
 void GUI_ShowSensors(void);
-void GUI_ResetSensorsPage(void);
 #endif // GUI_H_

--- a/RX671_MCR/src/RX671_MCR.c
+++ b/RX671_MCR/src/RX671_MCR.c
@@ -142,10 +142,14 @@ void main(void)
 		// ステータスバー表示
 		if(swValRotary != currentPage)
 		{
-		SSD1351fill(SSD1351_BLACK);
-		currentPage = swValRotary;
-		GUI_ShowStatusBar(currentPage);
-		}
+                SSD1351fill(SSD1351_BLACK);
+                currentPage = swValRotary;
+                GUI_ShowStatusBar(currentPage);
+                if(currentPage == 2)
+                {
+                        GUI_ResetSensorsPage();
+                }
+                }
 
 		// ページ表示
 		static uint8_t sel=0xff;

--- a/RX671_MCR/src/RX671_MCR.c
+++ b/RX671_MCR/src/RX671_MCR.c
@@ -121,13 +121,14 @@ void main(void)
 		, "INFO13  "
 	};
 
-	const uint8_t *menu2_items[] = {
-		  "Contrast"
-		, "Inverse "
-		, "QR code "
-	};
+        const uint8_t *menu2_items[] = {
+                  "Contrast"
+                , "Inverse "
+                , "QR code "
+        };
+        static uint8_t sel = 0xff;
 
-	while (1)
+        while (1)
 	{
 		if(!insertSDcard && initSDcard)
 		{
@@ -145,14 +146,10 @@ void main(void)
                 SSD1351fill(SSD1351_BLACK);
                 currentPage = swValRotary;
                 GUI_ShowStatusBar(currentPage);
-                if(currentPage == 2)
-                {
-                        GUI_ResetSensorsPage();
-                }
+                sel = 0xff;
                 }
 
 		// ページ表示
-		static uint8_t sel=0xff;
 
 		switch (currentPage) {
 			case 0:

--- a/RX671_MCR/src/RX671_MCR.c
+++ b/RX671_MCR/src/RX671_MCR.c
@@ -121,8 +121,9 @@ void main(void)
 		, "INFO13  "
 	};
 
-	const uint8_t *menu2_items[] = {
-			"Contrast"
+                if(swValRotary != currentPage)
+                {
+                GUI_ResetSensorsPage();
 		, "Inverse "
 		, "QR code "
 	};

--- a/RX671_MCR/src/RX671_MCR.c
+++ b/RX671_MCR/src/RX671_MCR.c
@@ -120,13 +120,12 @@ void main(void)
 		, "INFO12  "
 		, "INFO13  "
 	};
-
-        static uint8_t sel = 0xff; // SETTINGSページのメニュー選択
-                {
-                sel = 0xff;        // SETTINGSページ用選択状態をリセット
+    const uint8_t *menu2_items[] = {
+		  "Contrast"
+		, "Inverse "
 		, "QR code "
-	};
-	static uint8_t sel = 0xff;
+    };
+    static uint8_t sel = 0xff; // SETTINGSページのメニュー選択
 
 	while (1)
 	{

--- a/RX671_MCR/src/RX671_MCR.c
+++ b/RX671_MCR/src/RX671_MCR.c
@@ -155,9 +155,9 @@ void main(void)
 				// STARTページ
 				GUI_MenuSelect(menu1_items, 14);
 				break;
-			case 1:
-				// SETTINGSページ
-				switch (sel) {
+                       case 1:
+                               // SETTINGSページ
+                               switch (sel) {
 					case 0:
 						if(GUI_EditContrast())
 						{
@@ -178,11 +178,15 @@ void main(void)
 						break;
 					default:
 						sel = GUI_MenuSelect(menu2_items, 3);
-						break;
-				}
-				break;
-			default:
-				break;
+                                               break;
+                               }
+                               break;
+                        case 2:
+                                // SENSORページ
+                                GUI_ShowSensors();
+                                break;
+                        default:
+                                break;
 				
 		}
 

--- a/RX671_MCR/src/RX671_MCR.c
+++ b/RX671_MCR/src/RX671_MCR.c
@@ -121,9 +121,10 @@ void main(void)
 		, "INFO13  "
 	};
 
-                if(swValRotary != currentPage)
+        static uint8_t sel = 0xff; // SETTINGSページのメニュー選択
                 {
-		, "Inverse "
+                GUI_ResetSensorsPage();
+                sel = 0xff;        // SETTINGSページ用選択状態をリセット
 		, "QR code "
 	};
 	static uint8_t sel = 0xff;

--- a/RX671_MCR/src/RX671_MCR.c
+++ b/RX671_MCR/src/RX671_MCR.c
@@ -121,20 +121,21 @@ void main(void)
 		, "INFO13  "
 	};
 
-        const uint8_t *menu2_items[] = {
-                  "Contrast"
-                , "Inverse "
-                , "QR code "
-        };
-        static uint8_t sel = 0xff;
+	const uint8_t *menu2_items[] = {
+			"Contrast"
+		, "Inverse "
+		, "QR code "
+	};
+	static uint8_t sel = 0xff;
 
-        while (1)
+	while (1)
 	{
 		if(!insertSDcard && initSDcard)
 		{
 			// SDカードが抜かれた場合の処理
 			SDcardEnd(); // SDカードの終了処理
-		} else if(insertSDcard && !initSDcard)
+		}
+		else if(insertSDcard && !initSDcard)
 		{
 			SDcardinit(); // SDカードの初期化
 		}
@@ -143,22 +144,21 @@ void main(void)
 		// ステータスバー表示
 		if(swValRotary != currentPage)
 		{
-                SSD1351fill(SSD1351_BLACK);
-                currentPage = swValRotary;
-                GUI_ShowStatusBar(currentPage);
-                sel = 0xff;
-                }
+			SSD1351fill(SSD1351_BLACK);
+			currentPage = swValRotary;
+			GUI_ShowStatusBar(currentPage);
+			sel = 0xff;
+		}
 
 		// ページ表示
-
 		switch (currentPage) {
-			case 0:
-				// STARTページ
+			case 0x0:
+				// Startページ
 				GUI_MenuSelect(menu1_items, 14);
 				break;
-                       case 1:
-                               // SETTINGSページ
-                               switch (sel) {
+			case 0x1:
+				// Display settingページ
+				switch (sel) {
 					case 0:
 						if(GUI_EditContrast())
 						{
@@ -179,16 +179,15 @@ void main(void)
 						break;
 					default:
 						sel = GUI_MenuSelect(menu2_items, 3);
-                                               break;
-                               }
-                               break;
-                        case 2:
-                                // SENSORページ
-                                GUI_ShowSensors();
-                                break;
-                        default:
-                                break;
-				
+						break;
+				}
+				break;
+			case 0x2:
+				// Sensorページ
+				GUI_ShowSensors();
+				break;
+			default:
+				break;
 		}
 
 		// SSD1351setCursor(2,2);

--- a/RX671_MCR/src/RX671_MCR.c
+++ b/RX671_MCR/src/RX671_MCR.c
@@ -123,7 +123,6 @@ void main(void)
 
         static uint8_t sel = 0xff; // SETTINGSページのメニュー選択
                 {
-                GUI_ResetSensorsPage();
                 sel = 0xff;        // SETTINGSページ用選択状態をリセット
 		, "QR code "
 	};

--- a/RX671_MCR/src/RX671_MCR.c
+++ b/RX671_MCR/src/RX671_MCR.c
@@ -123,7 +123,6 @@ void main(void)
 
                 if(swValRotary != currentPage)
                 {
-                GUI_ResetSensorsPage();
 		, "Inverse "
 		, "QR code "
 	};

--- a/RX671_MCR/src/gui.c
+++ b/RX671_MCR/src/gui.c
@@ -389,33 +389,42 @@ bool GUI_ShowQRcode(void)
 /////////////////////////////////////////////////////////////////////
 void GUI_ShowSensors(void)
 {
+        // 表示領域をクリア
         SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1, SSD1351_HEIGHT - 1, SSD1351_BLACK);
 
+        // バッテリ電圧の取得
         GetBatteryVoltage();
 
+        // 1行目: バッテリ電圧
         SSD1351setCursor(2, MENU_START_Y);
         SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"BAT:%4.1fV", batteryVoltage);
 
+        // 2行目: IMU 角度(X,Y,Z)
         SSD1351setCursor(2, MENU_START_Y + 12);
         SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"ANG:%4d %4d %4d",
                         (int16_t)BMI088val.angle.x,
                         (int16_t)BMI088val.angle.y,
                         (int16_t)BMI088val.angle.z);
 
+        // 3行目: IMU 温度
         SSD1351setCursor(2, MENU_START_Y + 24);
         SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"TEMP:%3d", (int16_t)BMI088val.temp);
 
+        // 4行目: エンコーダ積算値
         SSD1351setCursor(2, MENU_START_Y + 36);
         SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"ENC:%ld", encTotal);
 
+        // 5行目: ラインセンサ0～2
         SSD1351setCursor(2, MENU_START_Y + 48);
         SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"LS:%4d %4d %4d",
                         lineSenVal[0], lineSenVal[1], lineSenVal[2]);
 
+        // 6行目: ラインセンサ3～5
         SSD1351setCursor(2, MENU_START_Y + 60);
         SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"%4d %4d %4d",
                         lineSenVal[3], lineSenVal[4], lineSenVal[5]);
 
+        // 7行目: ラインセンサ6
         SSD1351setCursor(2, MENU_START_Y + 72);
         SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"%4d", lineSenVal[6]);
 }

--- a/RX671_MCR/src/gui.c
+++ b/RX671_MCR/src/gui.c
@@ -22,18 +22,6 @@
 // グローバル変数の宣言
 //====================================//
 volatile uint32_t cntGUI;	// GUI用カウンタ
-static bool sensor_page_initialized = false; // センサページ初期化済みフラグ
-
-/////////////////////////////////////////////////////////////////////
-// モジュール名 GUI_ResetSensorsPage
-// 処理概要     センサページ初期化フラグをリセットする
-// 引数         なし
-// 戻り値       なし
-/////////////////////////////////////////////////////////////////////
-void GUI_ResetSensorsPage(void)
-{
-    sensor_page_initialized = false;
-}
 /////////////////////////////////////////////////////////////////////
 // モジュール名 GUI_wait
 // 処理概要     指定ミリ秒だけ待機する
@@ -392,12 +380,6 @@ bool GUI_ShowQRcode(void)
 /////////////////////////////////////////////////////////////////////
 void GUI_ShowSensors(void)
 {
-        if(!sensor_page_initialized)
-        {
-                SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1,
-                                        SSD1351_HEIGHT - 1, SSD1351_BLACK);
-                sensor_page_initialized = true;
-        }
 
         // バッテリ電圧の取得
         GetBatteryVoltage();

--- a/RX671_MCR/src/gui.c
+++ b/RX671_MCR/src/gui.c
@@ -1,11 +1,5 @@
 //====================================//
 // インクルード
-//====================================//
-#include "gui.h"
-#include "bmi088.h"
-#include "images.h"
-#include "ssd1351.h"
-#include "switch.h"
 #include "sys/types.h"
 #include "timer.h"
 #include <stdbool.h>
@@ -23,7 +17,6 @@
 // グローバル変数の宣言
 //====================================//
 volatile uint32_t cntGUI;	// GUI用カウンタ
-static bool sensor_page_initialized = false; // センサページ初期化フラグ
 /////////////////////////////////////////////////////////////////////
 // モジュール名 GUI_wait
 // 処理概要     指定ミリ秒だけ待機する
@@ -390,12 +383,6 @@ bool GUI_ShowQRcode(void)
 /////////////////////////////////////////////////////////////////////
 void GUI_ShowSensors(void)
 {
-        // センサページ選択直後のみ表示領域をクリア
-        if(!sensor_page_initialized)
-        {
-                SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1, SSD1351_HEIGHT - 1, SSD1351_BLACK);
-                sensor_page_initialized = true;
-        }
 
         // バッテリ電圧の取得
         GetBatteryVoltage();
@@ -432,15 +419,4 @@ void GUI_ShowSensors(void)
         // 7行目: ラインセンサ6
         SSD1351setCursor(2, MENU_START_Y + 72);
         SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"%4d", lineSenVal[6]);
-}
-
-/////////////////////////////////////////////////////////////////////
-// モジュール名 GUI_ResetSensorsPage
-// 処理概要     センサページ再表示時の初期化
-// 引数         なし
-// 戻り値       なし
-/////////////////////////////////////////////////////////////////////
-void GUI_ResetSensorsPage(void)
-{
-        sensor_page_initialized = false;
 }

--- a/RX671_MCR/src/gui.c
+++ b/RX671_MCR/src/gui.c
@@ -455,22 +455,28 @@ bool GUI_ShowSensors(void)
                 break;
 
         case SENSOR_IMU: // IMU各値を表示
-                // 角度
+                // 角度のヘッダー
                 SSD1351setCursor(2, MENU_START_Y);
+                SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"ANG");
+                // X/Y/Z の角度
+                SSD1351setCursor(2, MENU_START_Y + 12);
                 SSD1351printf(Font_7x10, SSD1351_WHITE,
-                              (uint8_t*)"ANG:%4d %4d %4d",
+                              (uint8_t*)"X:%4dY:%4dZ:%4d",
                               (int16_t)BMI088val.angle.x,
                               (int16_t)BMI088val.angle.y,
                               (int16_t)BMI088val.angle.z);
                 // 温度
-                SSD1351setCursor(2, MENU_START_Y + 12);
+                SSD1351setCursor(2, MENU_START_Y + 24);
                 SSD1351printf(Font_7x10, SSD1351_WHITE,
                               (uint8_t*)"TEMP:%3d",
                               (int16_t)BMI088val.temp);
-                // 加速度
-                SSD1351setCursor(2, MENU_START_Y + 24);
+                // 加速度のヘッダー
+                SSD1351setCursor(2, MENU_START_Y + 36);
+                SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"ACC");
+                // X/Y/Z の加速度
+                SSD1351setCursor(2, MENU_START_Y + 48);
                 SSD1351printf(Font_7x10, SSD1351_WHITE,
-                              (uint8_t*)"ACC:%4d %4d %4d",
+                              (uint8_t*)"X:%4dY:%4dZ:%4d",
                               (int16_t)BMI088val.accele.x,
                               (int16_t)BMI088val.accele.y,
                               (int16_t)BMI088val.accele.z);

--- a/RX671_MCR/src/gui.c
+++ b/RX671_MCR/src/gui.c
@@ -1,5 +1,10 @@
 //====================================//
 // インクルード
+#include "gui.h"
+#include "bmi088.h"
+#include "images.h"
+#include "ssd1351.h"
+#include "switch.h"
 #include "sys/types.h"
 #include "timer.h"
 #include <stdbool.h>
@@ -17,6 +22,18 @@
 // グローバル変数の宣言
 //====================================//
 volatile uint32_t cntGUI;	// GUI用カウンタ
+static bool sensor_page_initialized = false; // センサページ初期化済みフラグ
+
+/////////////////////////////////////////////////////////////////////
+// モジュール名 GUI_ResetSensorsPage
+// 処理概要     センサページ初期化フラグをリセットする
+// 引数         なし
+// 戻り値       なし
+/////////////////////////////////////////////////////////////////////
+void GUI_ResetSensorsPage(void)
+{
+    sensor_page_initialized = false;
+}
 /////////////////////////////////////////////////////////////////////
 // モジュール名 GUI_wait
 // 処理概要     指定ミリ秒だけ待機する
@@ -375,6 +392,12 @@ bool GUI_ShowQRcode(void)
 /////////////////////////////////////////////////////////////////////
 void GUI_ShowSensors(void)
 {
+        if(!sensor_page_initialized)
+        {
+                SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1,
+                                        SSD1351_HEIGHT - 1, SSD1351_BLACK);
+                sensor_page_initialized = true;
+        }
 
         // バッテリ電圧の取得
         GetBatteryVoltage();

--- a/RX671_MCR/src/gui.c
+++ b/RX671_MCR/src/gui.c
@@ -455,30 +455,46 @@ bool GUI_ShowSensors(void)
                 break;
 
         case SENSOR_IMU: // IMU各値を表示
-                // 角度のヘッダー
+                // 角度表示ヘッダー
                 SSD1351setCursor(2, MENU_START_Y);
                 SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"ANG");
-                // X/Y/Z の角度
+                // X軸角度
                 SSD1351setCursor(2, MENU_START_Y + 12);
                 SSD1351printf(Font_7x10, SSD1351_WHITE,
-                              (uint8_t*)"X:%4dY:%4dZ:%4d",
-                              (int16_t)BMI088val.angle.x,
-                              (int16_t)BMI088val.angle.y,
+                              (uint8_t*)"X:%4d",
+                              (int16_t)BMI088val.angle.x);
+                // Y軸角度
+                SSD1351setCursor(2, MENU_START_Y + 24);
+                SSD1351printf(Font_7x10, SSD1351_WHITE,
+                              (uint8_t*)"Y:%4d",
+                              (int16_t)BMI088val.angle.y);
+                // Z軸角度
+                SSD1351setCursor(2, MENU_START_Y + 36);
+                SSD1351printf(Font_7x10, SSD1351_WHITE,
+                              (uint8_t*)"Z:%4d",
                               (int16_t)BMI088val.angle.z);
                 // 温度
-                SSD1351setCursor(2, MENU_START_Y + 24);
+                SSD1351setCursor(2, MENU_START_Y + 48);
                 SSD1351printf(Font_7x10, SSD1351_WHITE,
                               (uint8_t*)"TEMP:%3d",
                               (int16_t)BMI088val.temp);
-                // 加速度のヘッダー
-                SSD1351setCursor(2, MENU_START_Y + 36);
+                // 加速度表示ヘッダー
+                SSD1351setCursor(2, MENU_START_Y + 60);
                 SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"ACC");
-                // X/Y/Z の加速度
-                SSD1351setCursor(2, MENU_START_Y + 48);
+                // X軸加速度
+                SSD1351setCursor(2, MENU_START_Y + 72);
                 SSD1351printf(Font_7x10, SSD1351_WHITE,
-                              (uint8_t*)"X:%4dY:%4dZ:%4d",
-                              (int16_t)BMI088val.accele.x,
-                              (int16_t)BMI088val.accele.y,
+                              (uint8_t*)"X:%4d",
+                              (int16_t)BMI088val.accele.x);
+                // Y軸加速度
+                SSD1351setCursor(2, MENU_START_Y + 84);
+                SSD1351printf(Font_7x10, SSD1351_WHITE,
+                              (uint8_t*)"Y:%4d",
+                              (int16_t)BMI088val.accele.y);
+                // Z軸加速度
+                SSD1351setCursor(2, MENU_START_Y + 96);
+                SSD1351printf(Font_7x10, SSD1351_WHITE,
+                              (uint8_t*)"Z:%4d",
                               (int16_t)BMI088val.accele.z);
                 if(swValTact == SW_PUSH)
                 {

--- a/RX671_MCR/src/gui.c
+++ b/RX671_MCR/src/gui.c
@@ -81,68 +81,60 @@ uint8_t GUI_MenuSelect(const char **items, uint8_t count)
 {
 	static uint8_t index = 0;
 	static uint8_t top   = 0;
-	static bool init = false;
-
-	if(!init)
-	{
-		SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1, SSD1351_HEIGHT - 1, SSD1351_BLACK);
-		GUI_ShowMenu(items, count, index, top);
-		init = true;
-	}
 	
+	GUI_ShowMenu(items, count, index, top);
 
 	switch(swValTact)
 	{
-	case SW_UP:
-		// UP が押された場合
-		if(index == 0)
-		{
-			// 先頭からUPで末尾へ循環
-			index = count - 1;
-			if(count > MAX_VISIBLE_ITEMS)
+		case SW_UP:
+			// UP が押された場合
+			if(index == 0)
 			{
-				top = count - MAX_VISIBLE_ITEMS;
+				// 先頭からUPで末尾へ循環
+				index = count - 1;
+				if(count > MAX_VISIBLE_ITEMS)
+				{
+					top = count - MAX_VISIBLE_ITEMS;
+				}
 			}
-		}
-		else
-		{
-			index--;
-			// 表示範囲より上に移動した場合はスクロール
-			if(index < top)
+			else
 			{
-				top--;
+				index--;
+				// 表示範囲より上に移動した場合はスクロール
+				if(index < top)
+				{
+					top--;
+				}
 			}
-		}
-		GUI_ShowMenu(items, count, index, top);
-		R_BSP_SoftwareDelay(150, BSP_DELAY_MILLISECS);
-		break;
-	case SW_DOWN:
-		// DOWN が押された場合
-		if(index + 1 >= count)
-		{
-			// 末尾からDOWNで先頭へ循環
-			index = 0;
-			top   = 0;
-		}
-		else
-		{
-			index++;
-			// 表示範囲を超えたら下方向へスクロール
-			if(index >= top + MAX_VISIBLE_ITEMS)
+			GUI_ShowMenu(items, count, index, top);
+			R_BSP_SoftwareDelay(150, BSP_DELAY_MILLISECS);
+			break;
+		case SW_DOWN:
+			// DOWN が押された場合
+			if(index + 1 >= count)
 			{
-				top++;
+				// 末尾からDOWNで先頭へ循環
+				index = 0;
+				top   = 0;
 			}
-		}
-		GUI_ShowMenu(items, count, index, top);
-		R_BSP_SoftwareDelay(150, BSP_DELAY_MILLISECS);
-		break;
-	case SW_PUSH:
-		// 決定ボタンが押されたら現在の項目を返す
-		R_BSP_SoftwareDelay(150, BSP_DELAY_MILLISECS);
-		init = false;
-		return index;
-	default:
-		break;
+			else
+			{
+				index++;
+				// 表示範囲を超えたら下方向へスクロール
+				if(index >= top + MAX_VISIBLE_ITEMS)
+				{
+					top++;
+				}
+			}
+			GUI_ShowMenu(items, count, index, top);
+			R_BSP_SoftwareDelay(150, BSP_DELAY_MILLISECS);
+			break;
+		case SW_PUSH:
+			// 決定ボタンが押されたら現在の項目を返す
+			R_BSP_SoftwareDelay(150, BSP_DELAY_MILLISECS);
+			return index;
+		default:
+			break;
 	}
 
 	return 0xFF;
@@ -173,23 +165,23 @@ void GUI_ShowStatusBar(uint8_t page)
 /////////////////////////////////////////////////////////////////////
 void GUI_DrawTestPattern(uint8_t y_start)
 {
-        const uint16_t colors[8] = {
-                SSD1351_WHITE,
-                SSD1351_YELLOW,
-                SSD1351_CYAN,
-                SSD1351_GREEN,
-                SSD1351_MAGENTA,
-                SSD1351_RED,
-                SSD1351_BLUE,
-                SSD1351_BLACK
-        };
-        uint8_t width = SSD1351_WIDTH / 8;
-        for(uint8_t i = 0; i < 8; i++)
-        {
-			uint8_t x1 = i * width;
-			uint8_t x2 = (i + 1) * width - 1;
-			SSD1351fillRectangle(x1, y_start, x2, SSD1351_HEIGHT - 1, colors[i]);
-        }
+	const uint16_t colors[8] = {
+			SSD1351_WHITE,
+			SSD1351_YELLOW,
+			SSD1351_CYAN,
+			SSD1351_GREEN,
+			SSD1351_MAGENTA,
+			SSD1351_RED,
+			SSD1351_BLUE,
+			SSD1351_BLACK
+	};
+	uint8_t width = SSD1351_WIDTH / 8;
+	for(uint8_t i = 0; i < 8; i++)
+	{
+		uint8_t x1 = i * width;
+		uint8_t x2 = (i + 1) * width - 1;
+		SSD1351fillRectangle(x1, y_start, x2, SSD1351_HEIGHT - 1, colors[i]);
+	}
 }
 
 /////////////////////////////////////////////////////////////////////
@@ -200,90 +192,90 @@ void GUI_DrawTestPattern(uint8_t y_start)
 /////////////////////////////////////////////////////////////////////
 bool GUI_EditContrast(void)
 {
-        static uint8_t contrast[4] = {0x08, 0x64, 0x64, 0x64};
-        static uint8_t index = 0; // 0:R 1:G 2:B
-        static bool init = false;
+	static uint8_t contrast[4] = {0x08, 0x64, 0x64, 0x64};
+	static uint8_t index = 0; // 0:R 1:G 2:B
+	static bool init = false;
 
-        if(!init)
-        {
-			// 初期化処理
-			SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1,
-													SSD1351_HEIGHT - 1, SSD1351_BLACK);
-			SSD1351setCursor(2, MENU_START_Y);
-			SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"CONTRAST");
-			GUI_DrawTestPattern(SSD1351_HEIGHT - 40);
-			bmi088_read_locked = true;
-			GUI_wait(200); // 200ms待機
-			init = true;
-        }
+	if(!init)
+	{
+		// 初期化処理
+		SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1,
+												SSD1351_HEIGHT - 1, SSD1351_BLACK);
+		SSD1351setCursor(2, MENU_START_Y);
+		SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"CONTRAST");
+		GUI_DrawTestPattern(SSD1351_HEIGHT - 40);
+		bmi088_read_locked = true;
+		GUI_wait(200); // 200ms待機
+		init = true;
+	}
 
-		const uint8_t *labels[] = {"MASTER","R","G","B"};
-        for(uint8_t i = 0; i < 4; i++)
-        {
-			uint16_t color = (i == index) ? SSD1351_YELLOW : SSD1351_WHITE;
-			if(i > 0)
+	const uint8_t *labels[] = {"MASTER","R","G","B"};
+	for(uint8_t i = 0; i < 4; i++)
+	{
+		uint16_t color = (i == index) ? SSD1351_YELLOW : SSD1351_WHITE;
+		if(i > 0)
+		{
+			SSD1351setCursor(2 + (40*(i-1)), MENU_START_Y + 24);
+		}
+		else
+		{
+			SSD1351setCursor(2, MENU_START_Y + 12);
+		}
+		SSD1351printf(Font_7x10, color, (uint8_t*)"%s:%3d", labels[i], contrast[i]);
+	}
+
+	switch(swValTact)
+	{
+		case SW_LEFT:
+			if(index == 0) index = 3; else index--;
+			GUI_wait(200);
+			break;
+		case SW_RIGHT:
+			index = (index + 1) % 4;
+			GUI_wait(200);
+			break;
+		case SW_UP:
+			display_update_locked = true;
+			while(!spi_BMI088_rx_done && !spi_ssd1351_tx_done);
+			if(index > 0)
 			{
-				SSD1351setCursor(2 + (40*(i-1)), MENU_START_Y + 24);
+				if(contrast[index] < 255) contrast[index]++;
+				SSD1351setContrastRGB(contrast[1], contrast[2], contrast[3]);
 			}
 			else
 			{
-				SSD1351setCursor(2, MENU_START_Y + 12);
+				if(contrast[index] < 15) contrast[index]++;
+				SSD1351setContrastMaster(contrast[0]);
 			}
-			SSD1351printf(Font_7x10, color, (uint8_t*)"%s:%3d", labels[i], contrast[i]);
-        }
-
-        switch(swValTact)
-        {
-			case SW_LEFT:
-				if(index == 0) index = 3; else index--;
-				GUI_wait(200);
-				break;
-			case SW_RIGHT:
-				index = (index + 1) % 4;
-				GUI_wait(200);
-				break;
-			case SW_UP:
-				display_update_locked = true;
-				while(!spi_BMI088_rx_done && !spi_ssd1351_tx_done);
-				if(index > 0)
-				{
-					if(contrast[index] < 255) contrast[index]++;
-					SSD1351setContrastRGB(contrast[1], contrast[2], contrast[3]);
-				}
-				else
-				{
-					if(contrast[index] < 15) contrast[index]++;
-					SSD1351setContrastMaster(contrast[0]);
-				}
-				display_update_locked = false;
-				GUI_wait(120);
-				break;
-			case SW_DOWN:
-				display_update_locked = true;
-				while(!spi_BMI088_rx_done && !spi_ssd1351_tx_done);
-				if(index > 0)
-				{
-					if(contrast[index] > 0) contrast[index]--;
-					SSD1351setContrastRGB(contrast[1], contrast[2], contrast[3]);
-				}
-				else
-				{
-					if(contrast[index] > 0) contrast[index]--;
-					SSD1351setContrastMaster(contrast[0]);
-				}
-				display_update_locked = false;
-				GUI_wait(120);
-				break;
-			case SW_PUSH:
-				GUI_wait(200); // 200ms待機
-				SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1,
-												SSD1351_HEIGHT - 1, SSD1351_BLACK);
-				bmi088_read_locked = false;
-				init = false;
-				return true;
-			default:
-				break;
-        }
+			display_update_locked = false;
+			GUI_wait(120);
+			break;
+		case SW_DOWN:
+			display_update_locked = true;
+			while(!spi_BMI088_rx_done && !spi_ssd1351_tx_done);
+			if(index > 0)
+			{
+				if(contrast[index] > 0) contrast[index]--;
+				SSD1351setContrastRGB(contrast[1], contrast[2], contrast[3]);
+			}
+			else
+			{
+				if(contrast[index] > 0) contrast[index]--;
+				SSD1351setContrastMaster(contrast[0]);
+			}
+			display_update_locked = false;
+			GUI_wait(120);
+			break;
+		case SW_PUSH:
+			GUI_wait(200); // 200ms待機
+			SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1,
+											SSD1351_HEIGHT - 1, SSD1351_BLACK);
+			bmi088_read_locked = false;
+			init = false;
+			return true;
+		default:
+			break;
+	}
 
 	return false;
 }

--- a/RX671_MCR/src/gui.c
+++ b/RX671_MCR/src/gui.c
@@ -378,5 +378,44 @@ bool GUI_ShowQRcode(void)
 	}
 	
 
-	return false;
+        return false;
+}
+
+/////////////////////////////////////////////////////////////////////
+// モジュール名 GUI_ShowSensors
+// 処理概要     各種センサの値を表示する
+// 引数         なし
+// 戻り値       なし
+/////////////////////////////////////////////////////////////////////
+void GUI_ShowSensors(void)
+{
+        SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1, SSD1351_HEIGHT - 1, SSD1351_BLACK);
+
+        GetBatteryVoltage();
+
+        SSD1351setCursor(2, MENU_START_Y);
+        SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"BAT:%4.1fV", batteryVoltage);
+
+        SSD1351setCursor(2, MENU_START_Y + 12);
+        SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"ANG:%4d %4d %4d",
+                        (int16_t)BMI088val.angle.x,
+                        (int16_t)BMI088val.angle.y,
+                        (int16_t)BMI088val.angle.z);
+
+        SSD1351setCursor(2, MENU_START_Y + 24);
+        SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"TEMP:%3d", (int16_t)BMI088val.temp);
+
+        SSD1351setCursor(2, MENU_START_Y + 36);
+        SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"ENC:%ld", encTotal);
+
+        SSD1351setCursor(2, MENU_START_Y + 48);
+        SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"LS:%4d %4d %4d",
+                        lineSenVal[0], lineSenVal[1], lineSenVal[2]);
+
+        SSD1351setCursor(2, MENU_START_Y + 60);
+        SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"%4d %4d %4d",
+                        lineSenVal[3], lineSenVal[4], lineSenVal[5]);
+
+        SSD1351setCursor(2, MENU_START_Y + 72);
+        SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"%4d", lineSenVal[6]);
 }

--- a/RX671_MCR/src/gui.c
+++ b/RX671_MCR/src/gui.c
@@ -23,6 +23,7 @@
 // グローバル変数の宣言
 //====================================//
 volatile uint32_t cntGUI;	// GUI用カウンタ
+static bool sensor_page_initialized = false; // センサページ初期化フラグ
 /////////////////////////////////////////////////////////////////////
 // モジュール名 GUI_wait
 // 処理概要     指定ミリ秒だけ待機する
@@ -389,8 +390,12 @@ bool GUI_ShowQRcode(void)
 /////////////////////////////////////////////////////////////////////
 void GUI_ShowSensors(void)
 {
-        // 表示領域をクリア
-        SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1, SSD1351_HEIGHT - 1, SSD1351_BLACK);
+        // センサページ選択直後のみ表示領域をクリア
+        if(!sensor_page_initialized)
+        {
+                SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1, SSD1351_HEIGHT - 1, SSD1351_BLACK);
+                sensor_page_initialized = true;
+        }
 
         // バッテリ電圧の取得
         GetBatteryVoltage();
@@ -427,4 +432,15 @@ void GUI_ShowSensors(void)
         // 7行目: ラインセンサ6
         SSD1351setCursor(2, MENU_START_Y + 72);
         SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"%4d", lineSenVal[6]);
+}
+
+/////////////////////////////////////////////////////////////////////
+// モジュール名 GUI_ResetSensorsPage
+// 処理概要     センサページ再表示時の初期化
+// 引数         なし
+// 戻り値       なし
+/////////////////////////////////////////////////////////////////////
+void GUI_ResetSensorsPage(void)
+{
+        sensor_page_initialized = false;
 }

--- a/RX671_MCR/src/gui.c
+++ b/RX671_MCR/src/gui.c
@@ -25,20 +25,16 @@ volatile uint32_t cntGUI;	// GUI用カウンタ
 /////////////////////////////////////////////////////////////////////
 // センサページ用の状態を保持する列挙体
 typedef enum {
-    SENSOR_MENU,     // トップメニュー
-    SENSOR_BAT,      // バッテリー電圧表示
-    SENSOR_IMU_MENU, // IMUサブメニュー
-    SENSOR_IMU_ANG,  // IMU角度表示
-    SENSOR_IMU_TEMP, // IMU温度表示
-    SENSOR_IMU_ACC,  // IMU加速度表示
-    SENSOR_ENC,      // エンコーダ値表示
-    SENSOR_LINE      // ラインセンサ値表示
+    SENSOR_MENU, // トップメニュー
+    SENSOR_BAT,  // バッテリー電圧表示
+    SENSOR_IMU,  // IMUの角度・温度・加速度表示
+    SENSOR_ENC,  // エンコーダ値表示
+    SENSOR_LINE  // ラインセンサ値表示
 } SensorState;
 
 // センサページの状態変数
 static SensorState sensor_state = SENSOR_MENU;
 static uint8_t     sensor_sel   = 0xff;
-static bool        sensor_init  = false;
 // モジュール名 GUI_wait
 // 処理概要     指定ミリ秒だけ待機する
 // 引数         ms: 待機時間(ミリ秒)
@@ -389,18 +385,6 @@ bool GUI_ShowQRcode(void)
 }
 
 /////////////////////////////////////////////////////////////////////
-// モジュール名 GUI_ResetSensorsPage
-// 処理概要     センサページの状態を初期化する
-// 引数         なし
-// 戻り値       なし
-/////////////////////////////////////////////////////////////////////
-void GUI_ResetSensorsPage(void)
-{
-    sensor_init  = false;
-    sensor_state = SENSOR_MENU;
-    sensor_sel   = 0xff;
-}
-/////////////////////////////////////////////////////////////////////
 // モジュール名 GUI_ShowSensors
 // 処理概要     センサ値をメニューで選択して個別表示する
 // 引数         なし
@@ -416,20 +400,9 @@ bool GUI_ShowSensors(void)
                   "Line    "
         };
 
-        const uint8_t *imu_items[] = {
-                  "Angle",
-                  "Temp ",
-                  "Accel",
-                  "Back "
-        };
-
-        if(!sensor_init)
+        if(sensor_state == SENSOR_MENU && sensor_sel == 0xff)
         {
-                SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1,
-                                                                SSD1351_HEIGHT - 1, SSD1351_BLACK);
-                sensor_sel   = 0xff;
-                sensor_state = SENSOR_MENU;
-                sensor_init  = true;
+                sensor_sel = GUI_MenuSelect(sensor_items, 4);
         }
 
         switch(sensor_state)
@@ -445,28 +418,25 @@ bool GUI_ShowSensors(void)
                         {
                         case 0:
                                 sensor_state = SENSOR_BAT;
-                                SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1,
-                                                            SSD1351_HEIGHT - 1, SSD1351_BLACK);
                                 break;
                         case 1:
-                                sensor_state = SENSOR_IMU_MENU;
-                                SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1,
-                                                            SSD1351_HEIGHT - 1, SSD1351_BLACK);
+                                sensor_state = SENSOR_IMU;
                                 break;
                         case 2:
                                 sensor_state = SENSOR_ENC;
-                                SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1,
-                                                            SSD1351_HEIGHT - 1, SSD1351_BLACK);
                                 break;
                         case 3:
                                 sensor_state = SENSOR_LINE;
-                                SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1,
-                                                            SSD1351_HEIGHT - 1, SSD1351_BLACK);
                                 break;
                         default:
                                 break;
                         }
-                        if(sensor_state != SENSOR_MENU) sensor_sel = 0xff;
+                        if(sensor_state != SENSOR_MENU)
+                        {
+                                sensor_sel = 0xff;
+                                SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1,
+                                                        SSD1351_HEIGHT - 1, SSD1351_BLACK);
+                        }
                 }
                 break;
 
@@ -484,84 +454,32 @@ bool GUI_ShowSensors(void)
                 }
                 break;
 
-        case SENSOR_IMU_MENU: // IMUメニュー
-                if(sensor_sel == 0xff)
-                {
-                        sensor_sel = GUI_MenuSelect(imu_items, 4);
-                }
-                else
-                {
-                        switch(sensor_sel)
-                        {
-                        case 0:
-                                sensor_state = SENSOR_IMU_ANG;
-                                SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1,
-                                                            SSD1351_HEIGHT - 1, SSD1351_BLACK);
-                                break;
-                        case 1:
-                                sensor_state = SENSOR_IMU_TEMP;
-                                SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1,
-                                                            SSD1351_HEIGHT - 1, SSD1351_BLACK);
-                                break;
-                        case 2:
-                                sensor_state = SENSOR_IMU_ACC;
-                                SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1,
-                                                            SSD1351_HEIGHT - 1, SSD1351_BLACK);
-                                break;
-                        case 3:
-                                sensor_state = SENSOR_MENU;
-                                SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1,
-                                                            SSD1351_HEIGHT - 1, SSD1351_BLACK);
-                                break;
-                        default:
-                                break;
-                        }
-                        if(sensor_state != SENSOR_IMU_MENU) sensor_sel = 0xff;
-                }
-                break;
-
-        case SENSOR_IMU_ANG: // 角度表示
+        case SENSOR_IMU: // IMU各値を表示
+                // 角度
                 SSD1351setCursor(2, MENU_START_Y);
-                SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"ANG:%4d %4d %4d",
-                                (int16_t)BMI088val.angle.x,
-                                (int16_t)BMI088val.angle.y,
-                                (int16_t)BMI088val.angle.z);
+                SSD1351printf(Font_7x10, SSD1351_WHITE,
+                              (uint8_t*)"ANG:%4d %4d %4d",
+                              (int16_t)BMI088val.angle.x,
+                              (int16_t)BMI088val.angle.y,
+                              (int16_t)BMI088val.angle.z);
+                // 温度
+                SSD1351setCursor(2, MENU_START_Y + 12);
+                SSD1351printf(Font_7x10, SSD1351_WHITE,
+                              (uint8_t*)"TEMP:%3d",
+                              (int16_t)BMI088val.temp);
+                // 加速度
+                SSD1351setCursor(2, MENU_START_Y + 24);
+                SSD1351printf(Font_7x10, SSD1351_WHITE,
+                              (uint8_t*)"ACC:%4d %4d %4d",
+                              (int16_t)BMI088val.accele.x,
+                              (int16_t)BMI088val.accele.y,
+                              (int16_t)BMI088val.accele.z);
                 if(swValTact == SW_PUSH)
                 {
                         GUI_wait(150);
                         SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1,
-                                                        SSD1351_HEIGHT - 1, SSD1351_BLACK);
-                        sensor_state = SENSOR_IMU_MENU;
-                        sensor_sel   = 0xff;
-                }
-                break;
-
-        case SENSOR_IMU_TEMP: // 温度表示
-                SSD1351setCursor(2, MENU_START_Y);
-                SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"TEMP:%3d",
-                                (int16_t)BMI088val.temp);
-                if(swValTact == SW_PUSH)
-                {
-                        GUI_wait(150);
-                        SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1,
-                                                        SSD1351_HEIGHT - 1, SSD1351_BLACK);
-                        sensor_state = SENSOR_IMU_MENU;
-                        sensor_sel   = 0xff;
-                }
-                break;
-
-        case SENSOR_IMU_ACC: // 加速度表示
-                SSD1351setCursor(2, MENU_START_Y);
-                SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"ACC:%4d %4d %4d",
-                                (int16_t)BMI088val.accele.x,
-                                (int16_t)BMI088val.accele.y,
-                                (int16_t)BMI088val.accele.z);
-                if(swValTact == SW_PUSH)
-                {
-                        GUI_wait(150);
-                        SSD1351fillRectangle(0, MENU_START_Y, SSD1351_WIDTH - 1,
-                                                        SSD1351_HEIGHT - 1, SSD1351_BLACK);
-                        sensor_state = SENSOR_IMU_MENU;
+                                                SSD1351_HEIGHT - 1, SSD1351_BLACK);
+                        sensor_state = SENSOR_MENU;
                         sensor_sel   = 0xff;
                 }
                 break;


### PR DESCRIPTION
## Summary
- show a new sensor page when the rotary switch value is 0x2
- display battery voltage, IMU angles, encoder count and line sensor values

## Testing
- `cmake ..`
- `make -j4` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_684793496a948323b60e2f99f4148013