### PR TITLE
Move remaining init check inside calcDegrees

### DIFF
--- a/RX671_MCR/src/BMI088.c
+++ b/RX671_MCR/src/BMI088.c
@@ -159,12 +159,12 @@ bool BMI088init(void)
 /////////////////////////////////////////////////////////////////////
 void BMI088getGyro(void)
 {
-        if(!BMI088val.Initialized)
-        {
-                return;
-        }
-        uint8_t rawData[6];
-        int16_t gyroVal[3];
+	if(!BMI088val.Initialized)
+	{
+		return;
+	}
+	uint8_t rawData[6];
+	int16_t gyroVal[3];
 
 	// 角速度の生データを取得
 	BMI088readAxisData(GYRO, REG_RATE_X_LSB, rawData, 6);
@@ -186,12 +186,12 @@ void BMI088getGyro(void)
 /////////////////////////////////////////////////////////////////////
 void BMI088getAccele(void)
 {
-        if(!BMI088val.Initialized)
-        {
-                return;
-        }
-        uint8_t rawData[8];
-        int16_t accelVal[3];
+	if(!BMI088val.Initialized)
+	{
+		return;
+	}
+	uint8_t rawData[8];
+	int16_t accelVal[3];
 
 	// 加速度の生データを取得
 	BMI088readAxisData(ACCELE, REG_ACC_X_LSB, rawData, 7);
@@ -213,13 +213,13 @@ void BMI088getAccele(void)
 /////////////////////////////////////////////////////////////////////
 void BMI088getTemp(void)
 {
-        if(!BMI088val.Initialized)
-        {
-                return;
-        }
-        uint8_t rawData[3];
-        uint16_t tempValu;
-        int16_t tempVal;
+	if(!BMI088val.Initialized)
+	{
+		return;
+	}
+	uint8_t rawData[3];
+	uint16_t tempValu;
+	int16_t tempVal;
 
 	// 温度の生データを取得
 	BMI088readAxisData(ACCELE, REG_TEMP_MSB, rawData, 3);
@@ -245,10 +245,10 @@ void BMI088getTemp(void)
 /////////////////////////////////////////////////////////////////////
 void calcDegrees(void)
 {
-       if(!BMI088val.Initialized)
-       {
-               return;
-       }
+	if(!BMI088val.Initialized)
+	{
+		return;
+	}
 	// ジャイロ積分による角度更新 度数法
     BMI088val.angle.x += BMI088val.gyro.x * DEFF_TIME;  // pitch
     BMI088val.angle.y += BMI088val.gyro.y * DEFF_TIME;  // roll

--- a/RX671_MCR/src/BMI088.c
+++ b/RX671_MCR/src/BMI088.c
@@ -159,8 +159,12 @@ bool BMI088init(void)
 /////////////////////////////////////////////////////////////////////
 void BMI088getGyro(void)
 {
-	uint8_t rawData[6];
-	int16_t gyroVal[3];
+        if(!BMI088val.Initialized)
+        {
+                return;
+        }
+        uint8_t rawData[6];
+        int16_t gyroVal[3];
 
 	// 角速度の生データを取得
 	BMI088readAxisData(GYRO, REG_RATE_X_LSB, rawData, 6);
@@ -182,8 +186,12 @@ void BMI088getGyro(void)
 /////////////////////////////////////////////////////////////////////
 void BMI088getAccele(void)
 {
-	uint8_t rawData[8];
-	int16_t accelVal[3];
+        if(!BMI088val.Initialized)
+        {
+                return;
+        }
+        uint8_t rawData[8];
+        int16_t accelVal[3];
 
 	// 加速度の生データを取得
 	BMI088readAxisData(ACCELE, REG_ACC_X_LSB, rawData, 7);
@@ -205,9 +213,13 @@ void BMI088getAccele(void)
 /////////////////////////////////////////////////////////////////////
 void BMI088getTemp(void)
 {
-	uint8_t rawData[3];
-	uint16_t tempValu;
-	int16_t tempVal;
+        if(!BMI088val.Initialized)
+        {
+                return;
+        }
+        uint8_t rawData[3];
+        uint16_t tempValu;
+        int16_t tempVal;
 
 	// 温度の生データを取得
 	BMI088readAxisData(ACCELE, REG_TEMP_MSB, rawData, 3);
@@ -233,6 +245,10 @@ void BMI088getTemp(void)
 /////////////////////////////////////////////////////////////////////
 void calcDegrees(void)
 {
+       if(!BMI088val.Initialized)
+       {
+               return;
+       }
 	// ジャイロ積分による角度更新 度数法
     BMI088val.angle.x += BMI088val.gyro.x * DEFF_TIME;  // pitch
     BMI088val.angle.y += BMI088val.gyro.y * DEFF_TIME;  // roll

--- a/RX671_MCR/src/timer.c
+++ b/RX671_MCR/src/timer.c
@@ -33,13 +33,13 @@ void interrupt1ms(void * pdata)
 	{
 	case 1:
 		
-		if(BMI088val.Initialized && !calibratIMU && !bmi088_read_locked)
+		if(!calibratIMU && !bmi088_read_locked)
 		{
-			BMI088getGyro(); // 角速度取得
-			BMI088getTemp();
-			BMI088getAccele();
-			calcDegrees();	 // 角度計算
-		}
+                       BMI088getGyro(); // 角速度取得
+                       BMI088getTemp();
+                       BMI088getAccele();
+                       calcDegrees();   // 角度計算
+               }
 		
 		break;
 	case 2:

--- a/RX671_MCR/src/timer.c
+++ b/RX671_MCR/src/timer.c
@@ -32,15 +32,13 @@ void interrupt1ms(void * pdata)
 	switch (cnt10)
 	{
 	case 1:
-		
 		if(!calibratIMU && !bmi088_read_locked)
 		{
-                       BMI088getGyro(); // 角速度取得
-                       BMI088getTemp();
-                       BMI088getAccele();
-                       calcDegrees();   // 角度計算
-               }
-		
+		   BMI088getGyro(); // 角速度取得
+		   BMI088getTemp();
+		   BMI088getAccele();
+		   calcDegrees();   // 角度計算
+		}
 		break;
 	case 2:
 		if(calibratIMU)


### PR DESCRIPTION
## Summary
- move initialization check into `calcDegrees`
- always call `calcDegrees` from timer interrupt

## Testing
- `cmake -S RX671_MCR -B build`
- `cmake --build build -j $(nproc)` *(fails: unrecognized command-line option)*

------
https://chatgpt.com/codex/tasks/task_e_6847b561a2a883239837ea837a191b79