### PR TITLE
Maintain menu top offset per menu

### DIFF
--- a/RX671_MCR/inc/setup.h
+++ b/RX671_MCR/inc/setup.h
@@ -20,6 +20,7 @@
 #define MENU_START_Y 12
 #define MENU_ITEM_HEIGHT 12
 #define MAX_VISIBLE_ITEMS (((SSD1351_HEIGHT - MENU_START_Y) / MENU_ITEM_HEIGHT) + 1)
+#define MAX_MENU_STATE 16
 
 //====================================//
 // グローバル変数の宣言


### PR DESCRIPTION
## Summary
- add `MenuState` table to remember scroll offset for each menu
- update `GUI_MenuSelect` to use stored offset values
- expand `MAX_MENU_STATE` to 16
- add explanatory comments in `GetMenuTop`
- add module comment for `GetMenuTop`
- relocate `GetMenuTop` after `GUI_ShowMenu` for code clarity
- move `MAX_MENU_STATE` definition to `setup.h`

## Testing
- `cmake ../RX671_MCR -DCMAKE_TOOLCHAIN_FILE=../RX671_MCR/cross.cmake` *(fails: compiler not found)*
- `cmake --build .` *(fails: Makefile missing)*

------
https://chatgpt.com/codex/tasks/task_e_688ccb11739483239744cdee081a2b40