### PR TITLE
Fix float printf freeze for SSD1351 display

### DIFF
--- a/RX671_MCR/.settings/e2studio_project.prefs
+++ b/RX671_MCR/.settings/e2studio_project.prefs
@@ -1,3 +1,3 @@
 #
-#Wed Aug 06 00:59:26 JST 2025
+#Wed Aug 06 21:05:25 JST 2025
 activeConfiguration=com.renesas.cdt.managedbuild.gcc.rx.configuration.debug.update.1331949664

--- a/RX671_MCR/src/setup.c
+++ b/RX671_MCR/src/setup.c
@@ -483,7 +483,7 @@ bool GUI_ShowSensors(void)
         case SENSOR_BAT:
             GetBatteryVoltage();
             SSD1351setCursor(2, MENU_START_Y);
-            SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"BAT:%4dV",(int16_t)batteryVoltage);
+            SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"BAT:%4.1fV",batteryVoltage);
             if(swValTact == SW_PUSH)
             {
                 GUI_wait(150);
@@ -497,21 +497,21 @@ bool GUI_ShowSensors(void)
             SSD1351setCursor(2, MENU_START_Y);
             SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"ANG");
             SSD1351setCursor(2, MENU_START_Y + 12);
-            SSD1351printf(Font_7x10, SSD1351_WHITE,(uint8_t*)"X:%4d",(int16_t)BMI088val.angle.x);
+            SSD1351printf(Font_7x10, SSD1351_WHITE,(uint8_t*)"X:%5.1f",BMI088val.angle.x);
             SSD1351setCursor(2, MENU_START_Y + 24);
-            SSD1351printf(Font_7x10, SSD1351_WHITE,(uint8_t*)"Y:%4d",(int16_t)BMI088val.angle.y);
+            SSD1351printf(Font_7x10, SSD1351_WHITE,(uint8_t*)"Y:%5.1f",BMI088val.angle.y);
             SSD1351setCursor(2, MENU_START_Y + 36);
-            SSD1351printf(Font_7x10, SSD1351_WHITE,(uint8_t*)"Z:%4d",(int16_t)BMI088val.angle.z);
+            SSD1351printf(Font_7x10, SSD1351_WHITE,(uint8_t*)"Z:%5.1f",BMI088val.angle.z);
             SSD1351setCursor(2, MENU_START_Y + 48);
-            SSD1351printf(Font_7x10, SSD1351_WHITE,(uint8_t*)"TEMP:%4d",(int16_t)BMI088val.temp);
+            SSD1351printf(Font_7x10, SSD1351_WHITE,(uint8_t*)"TEMP:%5.1f",BMI088val.temp);
             SSD1351setCursor(2, MENU_START_Y + 60);
             SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"ACC");
             SSD1351setCursor(2, MENU_START_Y + 72);
-            SSD1351printf(Font_7x10, SSD1351_WHITE,(uint8_t*)"X:%4d",(int16_t)BMI088val.accele.x);
+            SSD1351printf(Font_7x10, SSD1351_WHITE,(uint8_t*)"X:%5.1f",BMI088val.accele.x);
             SSD1351setCursor(2, MENU_START_Y + 84);
-            SSD1351printf(Font_7x10, SSD1351_WHITE,(uint8_t*)"Y:%4d",(int16_t)BMI088val.accele.y);
+            SSD1351printf(Font_7x10, SSD1351_WHITE,(uint8_t*)"Y:%5.1f",BMI088val.accele.y);
             SSD1351setCursor(2, MENU_START_Y + 96);
-            SSD1351printf(Font_7x10, SSD1351_WHITE,(uint8_t*)"Z:%4d",(int16_t)BMI088val.accele.z);
+            SSD1351printf(Font_7x10, SSD1351_WHITE,(uint8_t*)"Z:%5.1f",BMI088val.accele.z);
             if(swValTact == SW_PUSH)
             {
                 GUI_wait(150);
@@ -523,7 +523,7 @@ bool GUI_ShowSensors(void)
 
         case SENSOR_ENC:
             SSD1351setCursor(2, MENU_START_Y);
-            SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"ENC:%ld", encTotal);
+            SSD1351printf(Font_7x10, SSD1351_WHITE, (uint8_t*)"ENC:%7d", encTotal);
             if(swValTact == SW_PUSH)
             {
                 GUI_wait(150);

--- a/RX671_MCR/src/ssd1351.c
+++ b/RX671_MCR/src/ssd1351.c
@@ -455,7 +455,6 @@ static void SSD1351_ftoa(double value, char *buffer, size_t buffer_size, uint8_t
 // 処理概要     SSD1351用の簡易printf
 // 引数         Font:フォントサイズ color:16bitカラーコード
 //              format:フォーマット文字列 ...:書式化する値
-//              ※幅指定や精度指定は標準のprintfと同様に解釈される
 // 戻り値       なし
 ////////////////////////////////////////////////////////////////////
 void SSD1351printf(FontDef Font, uint16_t color, uint8_t *format, ...)

--- a/RX671_MCR/src/ssd1351.c
+++ b/RX671_MCR/src/ssd1351.c
@@ -3,6 +3,7 @@
 //====================================//
 #include "ssd1351.h"
 #include <stdint.h>
+#include <stdio.h>
 #include <math.h>
 #include <stdlib.h>
 //====================================//
@@ -405,14 +406,14 @@ void SSD1351setCursor(uint8_t x, uint8_t y)
 ////////////////////////////////////////////////////////////////////
 void SSD1351printf(FontDef Font, uint16_t color, uint8_t *format, ...)
 {
-	va_list argptr;
-	uint8_t str[SSD1351_WIDTH / 6]; // 最小フォント幅での最大文字数
+        va_list argptr;
+        uint8_t str[SSD1351_WIDTH + 1];
 
-	va_start(argptr, format);
-	vsprintf(str, format, argptr);
-	va_end(argptr);
+        va_start(argptr, format);
+        vsnprintf((char *)str, sizeof(str), (const char *)format, argptr);
+        va_end(argptr);
 
-	SSD1351writeString(str, Font, color);
+        SSD1351writeString(str, Font, color);
 }
 /////////////////////////////////////////////////////////////////////
 // モジュール名 SSD1351setDisplayOn

--- a/RX671_MCR/src/ssd1351.c
+++ b/RX671_MCR/src/ssd1351.c
@@ -455,7 +455,7 @@ static void SSD1351_ftoa(double value, char *buffer, size_t buffer_size, uint8_t
 // 処理概要     SSD1351用の簡易printf
 // 引数         Font:フォントサイズ color:16bitカラーコード
 //              format:フォーマット文字列 ...:書式化する値
-//              ※%fの幅指定は整数部の桁数として扱い、小数点以下と小数点分は自動で確保する
+//              ※幅指定や精度指定は標準のprintfと同様に解釈される
 // 戻り値       なし
 ////////////////////////////////////////////////////////////////////
 void SSD1351printf(FontDef Font, uint16_t color, uint8_t *format, ...)
@@ -541,21 +541,12 @@ void SSD1351printf(FontDef Font, uint16_t color, uint8_t *format, ...)
                         char tmp[32];
                         SSD1351_ftoa(val, tmp, sizeof(tmp), (uint8_t)precision);
                         size_t n = strnlen(tmp, sizeof(tmp));
-                        if (width > 0)
+                        if (width > 0 && (size_t)width > n)
                         {
-                                size_t required = width;
-                                if (precision > 0)
+                                size_t pad = (size_t)width - n;
+                                while (pad-- && (size_t)(dest - str) < SSD1351_WIDTH)
                                 {
-                                        /* 小数点以下と小数点の分を追加 */
-                                        required += precision + 1;
-                                }
-                                if (required > n)
-                                {
-                                        size_t pad = required - n;
-                                        while (pad-- && (size_t)(dest - str) < SSD1351_WIDTH)
-                                        {
-                                                *dest++ = ' ';
-                                        }
+                                        *dest++ = ' ';
                                 }
                         }
                         if ((size_t)(dest - str) + n > SSD1351_WIDTH)

--- a/RX671_MCR/src/ssd1351.c
+++ b/RX671_MCR/src/ssd1351.c
@@ -7,6 +7,7 @@
 #include <math.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <stdarg.h>
 //====================================//
 // グローバル変数の宣言
 //====================================//
@@ -474,6 +475,12 @@ void SSD1351printf(FontDef Font, uint16_t color, uint8_t *format, ...)
                 }
 
                 fmt++;
+                int width = 0;
+                while (isdigit((unsigned char)*fmt))
+                {
+                        width = width * 10 + (*fmt - '0');
+                        fmt++;
+                }
                 int precision = 2;
                 if (*fmt == '.')
                 {
@@ -492,7 +499,11 @@ void SSD1351printf(FontDef Font, uint16_t color, uint8_t *format, ...)
                 {
                         int val = va_arg(argptr, int);
                         size_t remain = sizeof(str) - (size_t)(dest - str);
-                        int n = snprintf(dest, remain, "%d", val);
+                        int n;
+                        if (width > 0)
+                                n = snprintf(dest, remain, "%*d", width, val);
+                        else
+                                n = snprintf(dest, remain, "%d", val);
                         if (n > 0)
                         {
                                 dest += n;
@@ -503,7 +514,11 @@ void SSD1351printf(FontDef Font, uint16_t color, uint8_t *format, ...)
                 {
                         int val = va_arg(argptr, int);
                         size_t remain = sizeof(str) - (size_t)(dest - str);
-                        int n = snprintf(dest, remain, "%x", val);
+                        int n;
+                        if (width > 0)
+                                n = snprintf(dest, remain, "%*x", width, val);
+                        else
+                                n = snprintf(dest, remain, "%x", val);
                         if (n > 0)
                         {
                                 dest += n;
@@ -525,6 +540,14 @@ void SSD1351printf(FontDef Font, uint16_t color, uint8_t *format, ...)
                         char tmp[32];
                         SSD1351_ftoa(val, tmp, sizeof(tmp), (uint8_t)precision);
                         size_t n = strnlen(tmp, sizeof(tmp));
+                        if (width > 0 && (size_t)width > n)
+                        {
+                                size_t pad = width - n;
+                                while (pad-- && (size_t)(dest - str) < SSD1351_WIDTH)
+                                {
+                                        *dest++ = ' ';
+                                }
+                        }
                         if ((size_t)(dest - str) + n > SSD1351_WIDTH)
                         {
                                 n = SSD1351_WIDTH - (size_t)(dest - str);

--- a/RX671_MCR/src/ssd1351.c
+++ b/RX671_MCR/src/ssd1351.c
@@ -455,6 +455,7 @@ static void SSD1351_ftoa(double value, char *buffer, size_t buffer_size, uint8_t
 // 処理概要     SSD1351用の簡易printf
 // 引数         Font:フォントサイズ color:16bitカラーコード
 //              format:フォーマット文字列 ...:書式化する値
+//              ※%fの幅指定は整数部の桁数として扱い、小数点以下と小数点分は自動で確保する
 // 戻り値       なし
 ////////////////////////////////////////////////////////////////////
 void SSD1351printf(FontDef Font, uint16_t color, uint8_t *format, ...)
@@ -540,12 +541,21 @@ void SSD1351printf(FontDef Font, uint16_t color, uint8_t *format, ...)
                         char tmp[32];
                         SSD1351_ftoa(val, tmp, sizeof(tmp), (uint8_t)precision);
                         size_t n = strnlen(tmp, sizeof(tmp));
-                        if (width > 0 && (size_t)width > n)
+                        if (width > 0)
                         {
-                                size_t pad = width - n;
-                                while (pad-- && (size_t)(dest - str) < SSD1351_WIDTH)
+                                size_t required = width;
+                                if (precision > 0)
                                 {
-                                        *dest++ = ' ';
+                                        /* 小数点以下と小数点の分を追加 */
+                                        required += precision + 1;
+                                }
+                                if (required > n)
+                                {
+                                        size_t pad = required - n;
+                                        while (pad-- && (size_t)(dest - str) < SSD1351_WIDTH)
+                                        {
+                                                *dest++ = ' ';
+                                        }
                                 }
                         }
                         if ((size_t)(dest - str) + n > SSD1351_WIDTH)

--- a/RX671_MCR/src/ssd1351.c
+++ b/RX671_MCR/src/ssd1351.c
@@ -400,7 +400,11 @@ void SSD1351setCursor(uint8_t x, uint8_t y)
         SSD1351.CurrentY = y;
 }
 /////////////////////////////////////////////////////////////////////
-// 文字列変換: 簡易浮動小数点→文字列
+// モジュール名 SSD1351_ftoa
+// 処理概要     簡易浮動小数点を文字列に変換する
+// 引数         value:変換する値 buffer:出力先バッファ
+//              buffer_size:バッファサイズ precision:小数点以下桁数
+// 戻り値       なし
 ////////////////////////////////////////////////////////////////////
 static void SSD1351_ftoa(double value, char *buffer, size_t buffer_size, uint8_t precision)
 {
@@ -449,6 +453,7 @@ static void SSD1351_ftoa(double value, char *buffer, size_t buffer_size, uint8_t
 // モジュール名 SSD1351printf
 // 処理概要     SSD1351用の簡易printf
 // 引数         Font:フォントサイズ color:16bitカラーコード
+//              format:フォーマット文字列 ...:書式化する値
 // 戻り値       なし
 ////////////////////////////////////////////////////////////////////
 void SSD1351printf(FontDef Font, uint16_t color, uint8_t *format, ...)


### PR DESCRIPTION
## Summary
- avoid buffer overflow in SSD1351printf by using vsnprintf with screen-sized buffer
- include stdio.h for printf prototypes

## Testing
- `cmake .. && make -j4` (fails: cc: error: unrecognized command-line option '-misa=v3')

------
https://chatgpt.com/codex/tasks/task_e_68922b1d92f8832397ed4e4a1b85287b