### PR TITLE
Handle start and pushcart selections

### DIFF
--- a/RX671_MCR/src/setup.c
+++ b/RX671_MCR/src/setup.c
@@ -1056,8 +1056,17 @@ void SetupUpdate(void)
     switch (currentPage) {
         case 0x0:
             // Startページ
-            GUI_MenuSelect((const char **)menu1_items,
-                           sizeof(menu1_items)/sizeof(menu1_items[0]));
+            {
+                uint8_t sel = GUI_MenuSelect((const char **)menu1_items,
+                                             sizeof(menu1_items)/sizeof(menu1_items[0]));
+                if (sel == 0) {
+                    start = 1;
+                    modePushcart = 0;
+                } else if (sel == 1) {
+                    start = 1;
+                    modePushcart = 1;
+                }
+            }
             break;
         case 0x1:
             // Display settingページ


### PR DESCRIPTION
## Summary
- Startページの選択で`start`および`modePushcart`を設定

## Testing
- `cmake -S RX671_MCR -B build` :heavy_check_mark:
- `cmake --build build` (失敗: unrecognized command-line option ‘-misa=v3’)


------
https://chatgpt.com/codex/tasks/task_e_6896c2d2607c83238cc89d6864ee09ed