### PR TITLE
fix: remove extra semicolon in start declaration

### DIFF
--- a/RX671_MCR/inc/setup.h
+++ b/RX671_MCR/inc/setup.h
@@ -28,7 +28,7 @@
 // グローバル変数の宣言
 //====================================//
 extern volatile uint32_t cntGUI;
-extern uint8_t 			start;; // 0:セットアップ中	1:セットアップ完了
+extern uint8_t 			start; // 0:セットアップ中	1:セットアップ完了
 extern uint8_t			modePushcart; // 手押しモードフラグ
 //====================================//
 // プロトタイプ宣言


### PR DESCRIPTION
## Summary
- correct `extern uint8_t start` declaration in `inc/setup.h`

## Testing
- `cmake -S RX671_MCR -B build`
- `cmake --build build` *(fails: unrecognized command-line option '-misa=v3')*

------
https://chatgpt.com/codex/tasks/task_e_689c0e1ead4c8323b74209397f6cf9a1