### PR TITLE
fix: update PIDcontrol include guard

### DIFF
--- a/RX671_MCR/inc/PIDcontrol.h
+++ b/RX671_MCR/inc/PIDcontrol.h
@@ -1,5 +1,5 @@
-#ifndef LINETRACE_H_
-#define LINETRACE_H_
+#ifndef PIDCONTROL_H_
+#define PIDCONTROL_H_
 //====================================//
 // インクルード
 //====================================//
@@ -55,4 +55,4 @@ void motorControlTrace(void);
 void motorControlSpeed(void);
 void motorControlAngle(void);
 
-#endif // LINETRACE_H_
+#endif // PIDCONTROL_H_


### PR DESCRIPTION
## Summary
- rename PIDcontrol include guard to PIDCONTROL_H_

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: unrecognized command-line option '-misa=v3')*


------
https://chatgpt.com/codex/tasks/task_e_689c0e12bc508323bbe2b65583b61df0