### PR TITLE
Fix BMI088 header include case

### DIFF
--- a/RX671_MCR/inc/setup.h
+++ b/RX671_MCR/inc/setup.h
@@ -7,7 +7,7 @@
 #include "ssd1351.h"
 #include "switch.h"
 #include "battery.h"
-#include "bmi088.h"
+#include "BMI088.h"
 #include "linesensor.h"
 #include "Motor.h"
 #include "encoder.h"


### PR DESCRIPTION
## Summary
- fix include case for BMI088 header in setup.h
- confirm BMI088 header usage is consistent

## Testing
- `cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=cross.cmake` *(fails: CMAKE_C_COMPILER is not a full path and was not found in the PATH)*

------
https://chatgpt.com/codex/tasks/task_e_689c0e175fc883239459df6fcfa1e7ce