### PR TITLE
Add delay and counter increment during SD card detection

### DIFF
--- a/RX671_MCR/src/SDcard.c
+++ b/RX671_MCR/src/SDcard.c
@@ -34,17 +34,17 @@ sdc_sd_status_t SDcardOpen(void)
 	{
 		// SDカードの検出を待機
 		cnt0 = 0;
-                while (R_SDC_SD_GetCardDetection(SD_CARD_NO) != SDC_SD_SUCCESS)
-                {
-                        cnt0++;
-                        R_BSP_SoftwareDelay(1, BSP_DELAY_MILLISECS);
-                        if (cnt0 > 2000)
-                        {
-                                // SDカードが検出されない場合の処理
-                                insertSDcard = 0; // SDカード挿入フラグをリセット
-                                return SDC_SD_ERR_NO_CARD;
-                        }
-                }
+		while (R_SDC_SD_GetCardDetection(SD_CARD_NO) != SDC_SD_SUCCESS)
+		{
+			cnt0++;
+			R_BSP_SoftwareDelay(1, BSP_DELAY_MILLISECS);
+			if (cnt0 > 2000)
+			{
+				// SDカードが検出されない場合の処理
+				insertSDcard = 0; // SDカード挿入フラグをリセット
+				return SDC_SD_ERR_NO_CARD;
+			}
+		}
 		insertSDcard = 1; // SDカード挿入フラグをセット
 
 		// SDカードの検出コールバック設定

--- a/RX671_MCR/src/SDcard.c
+++ b/RX671_MCR/src/SDcard.c
@@ -34,15 +34,17 @@ sdc_sd_status_t SDcardOpen(void)
 	{
 		// SDカードの検出を待機
 		cnt0 = 0;
-		while (R_SDC_SD_GetCardDetection(SD_CARD_NO) != SDC_SD_SUCCESS)
-		{
-			if (cnt0 > 2000)
-			{
-				// SDカードが検出されない場合の処理
-				insertSDcard = 0; // SDカード挿入フラグをリセット
-				return SDC_SD_ERR_NO_CARD;
-			}
-		}
+                while (R_SDC_SD_GetCardDetection(SD_CARD_NO) != SDC_SD_SUCCESS)
+                {
+                        cnt0++;
+                        R_BSP_SoftwareDelay(1, BSP_DELAY_MILLISECS);
+                        if (cnt0 > 2000)
+                        {
+                                // SDカードが検出されない場合の処理
+                                insertSDcard = 0; // SDカード挿入フラグをリセット
+                                return SDC_SD_ERR_NO_CARD;
+                        }
+                }
 		insertSDcard = 1; // SDカード挿入フラグをセット
 
 		// SDカードの検出コールバック設定


### PR DESCRIPTION
## Summary
- Ensure SD card detection loop counts attempts and yields time between polls
- Allow existing no-card error handling to trigger after a fixed timeout

## Testing
- `cmake -S RX671_MCR -B build -DCMAKE_TOOLCHAIN_FILE=/workspace/RX671_MCR/RX671_MCR/cross.cmake` *(fails: CMAKE_C_COMPILER not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c10443b408323bba928fc4506ede4